### PR TITLE
Fix environment variable leakage in test_session_paths.py

### DIFF
--- a/aops-core/tests/lib/test_session_paths.py
+++ b/aops-core/tests/lib/test_session_paths.py
@@ -8,11 +8,15 @@ from lib.session_paths import _is_gemini_session, get_gate_file_path, get_sessio
 @pytest.fixture(autouse=True)
 def _clear_env_vars(monkeypatch):
     """Clear env vars that leak from live sessions."""
-    monkeypatch.delenv("AOPS_SESSIONS", raising=False)
-    monkeypatch.delenv("AOPS_SESSION_STATE_DIR", raising=False)
-    monkeypatch.delenv("AOPS_HOOK_LOG_PATH", raising=False)
-    monkeypatch.delenv("AOPS_GATE_FILE_HYDRATION", raising=False)
-    monkeypatch.delenv("AOPS_GATE_FILE_CUSTODIET", raising=False)
+    ENV_VARS_TO_CLEAR = (
+        "AOPS_SESSIONS",
+        "AOPS_SESSION_STATE_DIR",
+        "AOPS_HOOK_LOG_PATH",
+        "AOPS_GATE_FILE_HYDRATION",
+        "AOPS_GATE_FILE_CUSTODIET",
+    )
+    for var in ENV_VARS_TO_CLEAR:
+        monkeypatch.delenv(var, raising=False)
 
 
 class TestIsGeminiSession:

--- a/aops-core/tests/lib/test_session_paths.py
+++ b/aops-core/tests/lib/test_session_paths.py
@@ -5,6 +5,16 @@ import pytest
 from lib.session_paths import _is_gemini_session, get_gate_file_path, get_session_short_hash
 
 
+@pytest.fixture(autouse=True)
+def _clear_env_vars(monkeypatch):
+    """Clear env vars that leak from live sessions."""
+    monkeypatch.delenv("AOPS_SESSIONS", raising=False)
+    monkeypatch.delenv("AOPS_SESSION_STATE_DIR", raising=False)
+    monkeypatch.delenv("AOPS_HOOK_LOG_PATH", raising=False)
+    monkeypatch.delenv("AOPS_GATE_FILE_HYDRATION", raising=False)
+    monkeypatch.delenv("AOPS_GATE_FILE_CUSTODIET", raising=False)
+
+
 class TestIsGeminiSession:
     """Tests for _is_gemini_session function."""
 
@@ -39,12 +49,6 @@ class TestIsGeminiSession:
 
 class TestGetGateFilePath:
     """Tests for get_gate_file_path function."""
-
-    @pytest.fixture(autouse=True)
-    def _clear_gate_env_vars(self, monkeypatch):
-        """Clear gate file env vars that leak from live sessions."""
-        monkeypatch.delenv("AOPS_GATE_FILE_HYDRATION", raising=False)
-        monkeypatch.delenv("AOPS_GATE_FILE_CUSTODIET", raising=False)
 
     def test_env_override(self):
         """Test that AOPS_GATE_FILE_<GATE> environment variable overrides the path."""

--- a/aops-core/tests/lib/test_session_paths.py
+++ b/aops-core/tests/lib/test_session_paths.py
@@ -14,6 +14,7 @@ def _clear_env_vars(monkeypatch):
         "AOPS_HOOK_LOG_PATH",
         "AOPS_GATE_FILE_HYDRATION",
         "AOPS_GATE_FILE_CUSTODIET",
+        "GEMINI_SESSION_ID",
     )
     for var in ENV_VARS_TO_CLEAR:
         monkeypatch.delenv(var, raising=False)


### PR DESCRIPTION
The test failures were not caused by incorrect test logic, but rather host environment variables (`AOPS_SESSIONS`, `AOPS_SESSION_STATE_DIR`, etc.) leaking into the test environment. These local variables superseded the mocked/temporary paths, leading to assertion mismatches and missing ValueErrors.

I've fixed this by introducing a module-level `autouse` fixture in `aops-core/tests/lib/test_session_paths.py` that clears these variables (`AOPS_SESSIONS`, `AOPS_SESSION_STATE_DIR`, `AOPS_HOOK_LOG_PATH`, `AOPS_GATE_FILE_HYDRATION`, and `AOPS_GATE_FILE_CUSTODIET`) using `monkeypatch.delenv(..., raising=False)`.

Tests now pass successfully even when the `AOPS_SESSIONS` environment variable is defined globally on the host.

---
*PR created automatically by Jules for task [9579714191488545425](https://jules.google.com/task/9579714191488545425) started by @nicsuzor*