### PR TITLE
fix(tests): Update hydration gate e2e test to read pyproject.toml instead of /etc/hosts

### DIFF
--- a/tests/e2e/test_gates_enforcement_e2e.py
+++ b/tests/e2e/test_gates_enforcement_e2e.py
@@ -26,7 +26,7 @@ class TestHydrationGateE2E:
         runner, platform = cli_headless
 
         result = runner(
-            "Read the file /etc/hosts and tell me what's in it. Do not use any other tools first.",
+            "Read the file pyproject.toml and tell me what's in it. Do not use any other tools first.",
             model="haiku" if platform == "claude" else None,
             fail_on_error=False,
         )


### PR DESCRIPTION
The e2e test `test_hydration_blocks_read_tool_before_hydration` was previously attempting to read `/etc/hosts`. This caused the LLM to inherently block the read due to the path being outside the permitted workspace directory, preventing the test from actually exercising the hydration gate logic. By changing the target file to `pyproject.toml` (which is safely within the workspace), the test now correctly verifies that the hydration gate itself is responsible for blocking the read operation.

---
*PR created automatically by Jules for task [9066971436151846044](https://jules.google.com/task/9066971436151846044) started by @nicsuzor*