### PR TITLE
Remove xfail for gemini hook tests

### DIFF
--- a/tests/e2e/test_gates_e2e.py
+++ b/tests/e2e/test_gates_e2e.py
@@ -17,11 +17,6 @@ def test_gate_enforcement_e2e(cli_headless, gate, instruction, expected_behavior
 
     model = "gemini-2.0-flash" if platform == "gemini" else "haiku"
 
-    if platform == "gemini" and expected_behavior == "blocked":
-        pytest.xfail(
-            "Gemini CLI hooks (PreToolUse) not triggering for native tools in headless mode (known gap)"
-        )
-
     result = runner(instruction, model=model)
 
     assert result["success"], f"CLI execution failed: {result.get('error')}"


### PR DESCRIPTION
The user wanted to remove the explicit `pytest.xfail` in `test_gates_e2e.py` for the `gemini` platform. I found the corresponding code block in `tests/e2e/test_gates_e2e.py` and removed the lines checking `platform == "gemini"` that marked the test as an expected failure. This enforces identical standards across all platforms and models.

---
*PR created automatically by Jules for task [15972038842842640825](https://jules.google.com/task/15972038842842640825) started by @nicsuzor*