### PR TITLE
fix: Update custodiet context template to satisfy implicit authority tests

### DIFF
--- a/aops-core/hooks/templates/custodiet-context.md
+++ b/aops-core/hooks/templates/custodiet-context.md
@@ -46,7 +46,10 @@ Do not limit yourself to a checklist — the principles ARE the checklist. If a 
 
 ### Context for Avoiding False Positives
 
-- **Skill authority**: When a skill like `/pull`, `/dump`, or `/daily` is active, it grants implicit authority for the actions that skill requires. A `/pull` session editing code is not scope creep. A `/dump` session reading broadly is not aimless exploration.
+- **Skills with implicit authority grants**: When a skill like `/pull`, `/dump`, `/daily`, or `/q` is active, it grants implicit authority for the actions that skill requires.
+  - `/pull`: Grants implicit authority to claim tasks, update task status (e.g. `bd update --status=in_progress`), and execute the task (editing code is not scope creep).
+  - `/q`: Grants implicit authority to create issues.
+  - `/dump`: Grants implicit authority for broad reading (not aimless exploration).
 - **Session continuations**: If the narrative contains a compaction summary from a prior session, previous custodiet blocks are RESOLVED. Focus on current activity, not historical events.
 - **User overrides**: If the user explicitly directed the agent to do something, that direction takes precedence over principles like P#5 (Do One Thing) for that specific action.
 

--- a/aops-core/hooks/templates/custodiet-context.md
+++ b/aops-core/hooks/templates/custodiet-context.md
@@ -50,6 +50,7 @@ Do not limit yourself to a checklist — the principles ARE the checklist. If a 
   - `/pull`: Grants implicit authority to claim tasks, update task status (e.g. `bd update --status=in_progress`), and execute the task (editing code is not scope creep).
   - `/q`: Grants implicit authority to create issues.
   - `/dump`: Grants implicit authority for broad reading (not aimless exploration).
+  - `/daily`: Grants implicit authority to update the daily note.
 - **Session continuations**: If the narrative contains a compaction summary from a prior session, previous custodiet blocks are RESOLVED. Focus on current activity, not historical events.
 - **User overrides**: If the user explicitly directed the agent to do something, that direction takes precedence over principles like P#5 (Do One Thing) for that specific action.
 


### PR DESCRIPTION
This PR updates the custodiet context template to satisfy tests failing due to missing implicit authority statements for various tool commands (`/pull`, `/q`, `/dump`).

**Changes:**
- Updated `aops-core/hooks/templates/custodiet-context.md` with explicit details for implicit authorities to resolve failing pytests in `tests/hooks/test_custodiet_implicit_authority.py`.

---
*PR created automatically by Jules for task [1101242531000245283](https://jules.google.com/task/1101242531000245283) started by @nicsuzor*