### PR TITLE
fix(polecat): skip checked-out worktree branches during mirror fetch

### DIFF
--- a/polecat/manager.py
+++ b/polecat/manager.py
@@ -657,12 +657,15 @@ class PolecatManager:
         if result.returncode != 0:
             return []
 
-        exclude = []
+        branches: set[str] = set()
         for line in result.stdout.splitlines():
             if line.startswith("branch refs/heads/"):
-                branch = line[len("branch refs/heads/") :]
-                exclude.append(f"^refs/heads/{branch}")
-        return exclude
+                raw_branch = line[len("branch refs/heads/") :]
+                branch = raw_branch.strip()
+                if branch:
+                    branches.add(branch)
+
+        return [f"^refs/heads/{branch}" for branch in sorted(branches)]
 
     def _ensure_local_remote(self, mirror_path: Path, local_path: Path) -> None:
         """Ensure mirror has a 'local' remote pointing to local repo.

--- a/polecat/manager.py
+++ b/polecat/manager.py
@@ -614,6 +614,9 @@ class PolecatManager:
                 # Build negative refspecs to exclude branches checked out in
                 # worktrees — git refuses to fetch into checked-out branches
                 exclude_refspecs = self._worktree_exclude_refspecs(mirror_path)
+                if exclude_refspecs:
+                    branches = [r.removeprefix("^refs/heads/") for r in exclude_refspecs]
+                    print(f"  Skipping worktree branches during fetch: {', '.join(branches)}")
 
                 # Fetch from origin (may fail if offline - that's OK)
                 origin_result = subprocess.run(

--- a/polecat/manager.py
+++ b/polecat/manager.py
@@ -611,9 +611,13 @@ class PolecatManager:
                 # This allows fetching unpushed commits from local working copy
                 self._ensure_local_remote(mirror_path, local_path)
 
+                # Build negative refspecs to exclude branches checked out in
+                # worktrees — git refuses to fetch into checked-out branches
+                exclude_refspecs = self._worktree_exclude_refspecs(mirror_path)
+
                 # Fetch from origin (may fail if offline - that's OK)
                 origin_result = subprocess.run(
-                    ["git", "fetch", "origin"],
+                    ["git", "fetch", "origin", *exclude_refspecs],
                     cwd=mirror_path,
                     capture_output=True,
                 )
@@ -622,7 +626,7 @@ class PolecatManager:
 
                 # Fetch from local repo (should always succeed)
                 subprocess.run(
-                    ["git", "fetch", "local"],
+                    ["git", "fetch", "local", *exclude_refspecs],
                     cwd=mirror_path,
                     check=True,
                     capture_output=True,
@@ -635,6 +639,30 @@ class PolecatManager:
             # Network errors, etc - non-fatal for offline operation
             print(f"⚠ Mirror sync failed for {project}: {e}", file=sys.stderr)
             return False
+
+    def _worktree_exclude_refspecs(self, mirror_path: Path) -> list[str]:
+        """Return negative refspecs to exclude branches checked out in worktrees.
+
+        Git refuses to fetch into a branch that is checked out in any worktree.
+        This method returns refspecs like '^refs/heads/branch' so that fetch
+        silently skips those branches instead of failing.
+        """
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=mirror_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return []
+
+        exclude = []
+        for line in result.stdout.splitlines():
+            if line.startswith("branch refs/heads/"):
+                branch = line[len("branch refs/heads/") :]
+                exclude.append(f"^refs/heads/{branch}")
+        return exclude
 
     def _ensure_local_remote(self, mirror_path: Path, local_path: Path) -> None:
         """Ensure mirror has a 'local' remote pointing to local repo.

--- a/tests/polecat/test_worktree_exclude_refspecs.py
+++ b/tests/polecat/test_worktree_exclude_refspecs.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Tests for _worktree_exclude_refspecs() in polecat/manager.py.
+
+Validates that the helper correctly parses `git worktree list --porcelain`
+output and returns negative refspecs for branches checked out in worktrees.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parents[2].resolve()
+sys.path.insert(0, str(REPO_ROOT / "polecat"))
+sys.path.insert(0, str(REPO_ROOT / "aops-core"))
+
+from manager import PolecatManager  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(["git"] + args, cwd=cwd, capture_output=True, text=True, check=check)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def bare_origin(tmp_path: Path) -> Path:
+    """Create a minimal bare repo that acts as 'origin'."""
+    origin = tmp_path / "origin.git"
+    _git(["init", "--bare", "-b", "main", str(origin)], cwd=tmp_path)
+
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _git(["init", "-b", "main", str(seed)], cwd=tmp_path)
+    _git(["config", "user.email", "test@test.example"], cwd=seed)
+    _git(["config", "user.name", "Test User"], cwd=seed)
+    (seed / "README.md").write_text("seed\n")
+    _git(["add", "."], cwd=seed)
+    _git(["commit", "-m", "init"], cwd=seed)
+    _git(["remote", "add", "origin", str(origin)], cwd=seed)
+    _git(["push", "-u", "origin", "main"], cwd=seed)
+    return origin
+
+
+@pytest.fixture()
+def local_clone(tmp_path: Path, bare_origin: Path) -> Path:
+    """Clone origin so main tracks origin/main."""
+    clone = tmp_path / "local"
+    _git(["clone", str(bare_origin), str(clone)], cwd=tmp_path)
+    _git(["config", "user.email", "test@test.example"], cwd=clone)
+    _git(["config", "user.name", "Test User"], cwd=clone)
+    return clone
+
+
+@pytest.fixture()
+def aca_data(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    data_dir = tmp_path / "aca_data"
+    data_dir.mkdir(exist_ok=True)
+    monkeypatch.setenv("ACA_DATA", str(data_dir))
+    return data_dir
+
+
+@pytest.fixture()
+def polecat_home(tmp_path: Path, local_clone: Path) -> Path:
+    home = tmp_path / "polecat_home"
+    home.mkdir()
+    config = {
+        "projects": {
+            "test": {
+                "path": str(local_clone),
+                "default_branch": "main",
+            }
+        },
+        "crew_names": ["test-worker"],
+    }
+    (home / "polecat.yaml").write_text(yaml.dump(config))
+    return home
+
+
+@pytest.fixture()
+def manager(polecat_home: Path, aca_data: Path) -> PolecatManager:
+    return PolecatManager(home_dir=polecat_home)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _worktree_exclude_refspecs()
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeExcludeRefspecs:
+    """Tests for the _worktree_exclude_refspecs() helper method."""
+
+    def test_no_worktrees_returns_empty(self, local_clone: Path, manager: PolecatManager):
+        """A repo with no linked worktrees returns no exclusions."""
+        result = manager._worktree_exclude_refspecs(local_clone)
+        # main is checked out in the main working tree, so it should appear
+        assert isinstance(result, list)
+
+    def test_with_linked_worktree(self, tmp_path: Path, local_clone: Path, manager: PolecatManager):
+        """A repo with a linked worktree excludes that branch."""
+        wt_path = tmp_path / "wt-feature"
+        _git(["worktree", "add", "-b", "feature-a", str(wt_path), "main"], cwd=local_clone)
+
+        result = manager._worktree_exclude_refspecs(local_clone)
+        assert "^refs/heads/feature-a" in result
+        assert "^refs/heads/main" in result
+
+    def test_multiple_worktrees(self, tmp_path: Path, local_clone: Path, manager: PolecatManager):
+        """Multiple linked worktrees produce multiple exclusions."""
+        for name in ["branch-x", "branch-y", "branch-z"]:
+            wt = tmp_path / f"wt-{name}"
+            _git(["worktree", "add", "-b", name, str(wt), "main"], cwd=local_clone)
+
+        result = manager._worktree_exclude_refspecs(local_clone)
+        for name in ["branch-x", "branch-y", "branch-z"]:
+            assert f"^refs/heads/{name}" in result
+
+    def test_results_are_sorted_and_deduplicated(self, manager: PolecatManager):
+        """Output is sorted and deduplicated."""
+        porcelain_output = (
+            "worktree /path/a\n"
+            "branch refs/heads/beta\n"
+            "\n"
+            "worktree /path/b\n"
+            "branch refs/heads/alpha\n"
+            "\n"
+            "worktree /path/c\n"
+            "branch refs/heads/beta\n"
+            "\n"
+        )
+        fake_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=porcelain_output, stderr=""
+        )
+        with patch("subprocess.run", return_value=fake_result):
+            result = manager._worktree_exclude_refspecs(Path("/fake"))
+
+        # Sorted and deduplicated: alpha before beta, beta only once
+        assert result == ["^refs/heads/alpha", "^refs/heads/beta"]
+
+    def test_command_failure_returns_empty(self, manager: PolecatManager):
+        """If git worktree list fails, returns empty list gracefully."""
+        fake_result = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="error")
+        with patch("subprocess.run", return_value=fake_result):
+            result = manager._worktree_exclude_refspecs(Path("/fake"))
+        assert result == []


### PR DESCRIPTION
## Summary
- `pc sync` fails when bare mirror tries to fetch into branches that are checked out in polecat worktrees
- `git worktree prune` (already present) only helps when worktree dirs are deleted; active worktrees still block fetch
- Adds `_worktree_exclude_refspecs()` helper that returns negative refspecs (`^refs/heads/branch`) for checked-out branches, letting fetch silently skip them

## Test plan
- [x] Verified exclude refspec logic correctly identifies all 4 active worktree branches
- [x] Verified `git fetch origin` with negative refspecs succeeds against real repo
- [x] Verified `git fetch local` with negative refspecs succeeds against real repo
- [ ] Run `pc sync` end-to-end after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)