### PR TITLE
fix: custodiet empty session narrative when entries pre-parsed

### DIFF
--- a/aops-core/lib/session_reader.py
+++ b/aops-core/lib/session_reader.py
@@ -373,12 +373,13 @@ def build_audit_session_context(
     Returns:
         Formatted markdown context suitable for critic agent consumption
     """
+    processor = SessionProcessor()
+
     if entries is None:
         path = Path(transcript_path)
         if not path.exists():
             return "(No transcript path available)"
 
-        processor = SessionProcessor()
         _, entries, _ = processor.parse_session_file(path, load_agents=False, load_hooks=False)
 
     if not entries:

--- a/tests/lib/test_session_reader.py
+++ b/tests/lib/test_session_reader.py
@@ -760,3 +760,47 @@ class TestSessionBoundaryValidation:
         # The processor should preserve timestamps so filtering is possible
         # Verify we have at least the 2 valid session entries
         assert len(conversation_turns) >= 2, "Should have at least the 2 valid session entries"
+
+
+class TestBuildAuditSessionContext:
+    """Tests for build_audit_session_context."""
+
+    def test_pre_parsed_entries_path(self, tmp_path):
+        """Regression: pre-parsed entries caused UnboundLocalError on processor.
+
+        When create_audit_file passes pre-parsed entries, build_audit_session_context
+        skipped processor creation, causing an UnboundLocalError on
+        processor.group_entries_into_turns(). Fixed by creating processor unconditionally.
+        See: nicsuzor/academicOps#228
+        """
+        from lib.session_reader import SessionProcessor, build_audit_session_context
+
+        # Create a minimal JSONL transcript
+        jsonl_path = tmp_path / "test-session.jsonl"
+        entries_data = [
+            {
+                "type": "user",
+                "uuid": "u1",
+                "timestamp": _make_timestamp(0),
+                "message": {"content": [{"type": "text", "text": "Hello world"}]},
+            },
+            {
+                "type": "assistant",
+                "uuid": "a1",
+                "timestamp": _make_timestamp(1),
+                "message": {"content": [{"type": "text", "text": "Hi, how can I help?"}]},
+            },
+        ]
+        jsonl_path.write_text("\n".join(json.dumps(e) for e in entries_data) + "\n")
+
+        # Parse entries separately (simulating create_audit_file's pattern)
+        processor = SessionProcessor()
+        _, entries, _ = processor.parse_session_file(
+            jsonl_path, load_agents=False, load_hooks=False
+        )
+        assert entries  # sanity check
+
+        # This was the failing call — entries passed but processor not created
+        result = build_audit_session_context(str(jsonl_path), entries=entries)
+        assert len(result) > 0
+        assert "Hello world" in result


### PR DESCRIPTION
## Summary

- **Root cause**: `build_audit_session_context()` only created `SessionProcessor` inside the `if entries is None` branch, but used it unconditionally on line 387. When `create_audit_file()` passed pre-parsed entries (the production path), `UnboundLocalError` was silently swallowed, producing an empty session narrative.
- **Fix**: Move `processor = SessionProcessor()` before the conditional branch so it's always available.
- **Regression test**: Added `TestBuildAuditSessionContext::test_pre_parsed_entries_path` covering the pre-parsed entries code path.

Closes #228

## Test plan

- [x] `uv run pytest tests/lib/test_session_reader.py` — all 22 tests pass (including new regression test)
- [x] Manual verification: `build_audit_session_context(path, entries=entries)` returns 15528 chars on live session JSONL
- [ ] Deploy updated plugin and verify custodiet audit files contain populated Session Narrative

🤖 Generated with [Claude Code](https://claude.com/claude-code)