### PR TITLE
fix: use staging directory for Docker auth file mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,8 +108,15 @@ RUN mkdir -p /home/worker/.gemini \
 # Make home dir and plugin dirs writable for any UID — polecat crew runs
 # containers as the host UID (non-root), which may differ from the worker
 # UID created above. Open permissions because the host UID varies per machine.
+# Make home dir writable for any UID — polecat crew runs containers as the
+# host UID (non-root), which may differ from worker UID 1000.
+# Remove .claude.json so the entrypoint can create it fresh with correct ownership.
+# Make home dir and .claude writable for any UID — polecat crew runs containers
+# as the host UID (non-root), which may differ from worker UID 1000.
+# Remove .claude.json so the entrypoint can create it fresh with correct ownership.
 RUN chmod 777 /home/worker \
-    && chmod -R a+w /home/worker/.claude/plugins/ 2>/dev/null || true
+    && chmod -R 777 /home/worker/.claude/ 2>/dev/null || true \
+    && rm -f /home/worker/.claude.json
 
 # Default command and entrypoint
 ENTRYPOINT ["/app/polecat/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,17 +105,11 @@ RUN claude plugin marketplace add /app \
 RUN mkdir -p /home/worker/.gemini \
     && GEMINI_API_KEY=dummy-for-install gemini extensions install /app/dist/aops-gemini --consent
 
-# Make home dir and plugin dirs writable for any UID — polecat crew runs
-# containers as the host UID (non-root), which may differ from the worker
-# UID created above. Open permissions because the host UID varies per machine.
-# Make home dir writable for any UID — polecat crew runs containers as the
-# host UID (non-root), which may differ from worker UID 1000.
-# Remove .claude.json so the entrypoint can create it fresh with correct ownership.
 # Make home dir and .claude writable for any UID — polecat crew runs containers
 # as the host UID (non-root), which may differ from worker UID 1000.
-# Remove .claude.json so the entrypoint can create it fresh with correct ownership.
+# Remove .claude.json so the entrypoint can populate it from staging with correct ownership.
 RUN chmod 777 /home/worker \
-    && chmod -R 777 /home/worker/.claude/ 2>/dev/null || true \
+    && (chmod -R 777 /home/worker/.claude/ 2>/dev/null || true) \
     && rm -f /home/worker/.claude.json
 
 # Default command and entrypoint

--- a/polecat/cli.py
+++ b/polecat/cli.py
@@ -268,8 +268,11 @@ def _build_docker_cmd(
         claude_dir = home / ".claude"
         # Create a staging directory under $HOME so Colima/Docker VMs can access it
         # (macOS VMs only share /Users, not /var/folders or /tmp).
-        staging_dir = home / ".aops" / "tmp" / f"staging-{os.getpid()}"
-        staging_dir.mkdir(parents=True, exist_ok=True)
+        # Use mkdtemp for a unique, non-guessable path; restrict to 0o700 since it holds auth material.
+        tmp_root = home / ".aops" / "tmp"
+        tmp_root.mkdir(parents=True, exist_ok=True)
+        staging_dir = Path(tempfile.mkdtemp(prefix="staging-", dir=tmp_root))
+        os.chmod(staging_dir, 0o700)
         if tmp_files is not None:
             tmp_files.append(staging_dir)
         if claude_json.exists():
@@ -280,7 +283,8 @@ def _build_docker_cmd(
                 config = json.load(f)
             config["bypassPermissionsModeAccepted"] = True
             staged_claude_json = staging_dir / ".claude.json"
-            with open(staged_claude_json, "w") as f:
+            fd = os.open(staged_claude_json, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
                 json.dump(config, f)
         if claude_dir.exists():
             # Copy only the auth files Claude needs at runtime — not the whole directory.

--- a/polecat/cli.py
+++ b/polecat/cli.py
@@ -266,37 +266,42 @@ def _build_docker_cmd(
     if cli_tool in ("claude", "shell"):
         claude_json = home / ".claude.json"
         claude_dir = home / ".claude"
+        # Create a staging directory under $HOME so Colima/Docker VMs can access it
+        # (macOS VMs only share /Users, not /var/folders or /tmp).
+        staging_dir = home / ".aops" / "tmp" / f"staging-{os.getpid()}"
+        staging_dir.mkdir(parents=True, exist_ok=True)
+        if tmp_files is not None:
+            tmp_files.append(staging_dir)
         if claude_json.exists():
             # Claude needs bypassPermissionsModeAccepted=true for --dangerously-skip-permissions
-            # to work without an interactive prompt. Create a temp copy with this flag set
+            # to work without an interactive prompt. Create a copy with this flag set
             # rather than modifying the user's actual config.
             with open(claude_json) as f:
                 config = json.load(f)
             config["bypassPermissionsModeAccepted"] = True
-            # Use NamedTemporaryFile (not deprecated mktemp) with delete=False
-            # so the file persists for Docker to mount. Caller cleans up via tmp_files.
-            tmp_fd = tempfile.NamedTemporaryFile(suffix=".claude.json", delete=False, mode="w")
-            json.dump(config, tmp_fd)
-            tmp_fd.close()
-            tmp_claude_json = Path(tmp_fd.name)
-            if tmp_files is not None:
-                tmp_files.append(tmp_claude_json)
-            cmd.extend(["-v", f"{tmp_claude_json}:{container_home}/.claude.json"])
+            staged_claude_json = staging_dir / ".claude.json"
+            with open(staged_claude_json, "w") as f:
+                json.dump(config, f)
         if claude_dir.exists():
-            # Mount only the auth files Claude needs at runtime — not the whole directory.
+            # Copy only the auth files Claude needs at runtime — not the whole directory.
             # The plugin installation is baked into the image (see Dockerfile), so mounting
             # the full ~/.claude dir would override the image's plugin data with the host's
             # (potentially stale or wrong-path) copy.
+            staged_claude_dir = staging_dir / ".claude"
+            staged_claude_dir.mkdir(exist_ok=True)
             for auth_file in (".credentials.json", ".mcp.json"):
                 src = claude_dir / auth_file
                 if src.exists():
-                    cmd.extend(["-v", f"{src}:{container_home}/.claude/{auth_file}:ro"])
+                    shutil.copy2(src, staged_claude_dir / auth_file)
+        cmd.extend(["-v", f"{staging_dir}:/tmp/staging:ro"])
 
-    # Mount Gemini auth files for "shell" mode so users can run gemini interactively.
+    # Stage Gemini auth files for "shell" mode so users can run gemini interactively.
     # Gemini normally handles its own sandbox, but in shell mode we're managing Docker.
     if cli_tool == "shell":
         gemini_dir = home / ".gemini"
         if gemini_dir.exists():
+            staged_gemini_dir = staging_dir / ".gemini"
+            staged_gemini_dir.mkdir(exist_ok=True)
             for auth_file in (
                 "settings.json",
                 "google_accounts.json",
@@ -306,7 +311,7 @@ def _build_docker_cmd(
             ):
                 src = gemini_dir / auth_file
                 if src.exists():
-                    cmd.extend(["-v", f"{src}:{container_home}/.gemini/{auth_file}:ro"])
+                    shutil.copy2(src, staged_gemini_dir / auth_file)
             # Also forward GEMINI_API_KEY if set
             gemini_key = env.get("GEMINI_API_KEY") or os.environ.get("GEMINI_API_KEY")
             if gemini_key:
@@ -2075,7 +2080,10 @@ def crew(ctx, target, extra, name, gemini, interactive, resume, keep):
             shutil.rmtree(tmp_gemini_home)
         # Clean up temporary files created by _build_docker_cmd
         for tmp_file in tmp_files:
-            tmp_file.unlink(missing_ok=True)
+            if tmp_file.is_dir():
+                shutil.rmtree(tmp_file, ignore_errors=True)
+            else:
+                tmp_file.unlink(missing_ok=True)
 
     print("-" * 50)
     print(f"\n\U0001f4cb Crew '{crew_name}' session ended.")
@@ -2570,7 +2578,10 @@ def run(ctx, project, caller, task_id, issue, no_finish, gemini, interactive, no
             shutil.rmtree(tmp_gemini_home)
         # Clean up temporary files created by _build_docker_cmd
         for tmp_file in tmp_files:
-            tmp_file.unlink(missing_ok=True)
+            if tmp_file.is_dir():
+                shutil.rmtree(tmp_file, ignore_errors=True)
+            else:
+                tmp_file.unlink(missing_ok=True)
 
     print("-" * 50)
 

--- a/polecat/entrypoint.sh
+++ b/polecat/entrypoint.sh
@@ -42,7 +42,10 @@ if [ -d /tmp/staging ]; then
     find /tmp/staging -type f | while read -r src; do
         dest="$HOME/${src#/tmp/staging/}"
         mkdir -p "$(dirname "$dest")"
-        cp --no-preserve=mode,ownership "$src" "$dest" 2>/dev/null || true
+        if ! cp --no-preserve=mode,ownership "$src" "$dest"; then
+            echo "Error: failed to copy staged file '$src' to '$dest'" >&2
+            exit 1
+        fi
     done
 fi
 

--- a/polecat/entrypoint.sh
+++ b/polecat/entrypoint.sh
@@ -34,5 +34,17 @@ fi
 export SSH_AUTH_SOCK=""
 export GIT_TERMINAL_PROMPT=0
 
+# Copy staged auth files into $HOME (avoids overlayfs file-mount bug on macOS
+# where chmod 777 on $HOME causes runc to treat file mounts as directories).
+# Copy staged files, overwriting image defaults. Use --no-preserve to avoid
+# permission errors when running as a different UID than the image's worker user.
+if [ -d /tmp/staging ]; then
+    find /tmp/staging -type f | while read -r src; do
+        dest="$HOME/${src#/tmp/staging/}"
+        mkdir -p "$(dirname "$dest")"
+        cp --no-preserve=mode,ownership "$src" "$dest" 2>/dev/null || true
+    done
+fi
+
 # Execute the agent command (e.g., claude, gemini, bash).
 exec "$@"

--- a/tests/polecat/test_cli_docker.py
+++ b/tests/polecat/test_cli_docker.py
@@ -137,7 +137,7 @@ class TestBuildDockerCmd:
         assert "AOPS_CUSTOM_VAR=value" in env_args
 
     def test_claude_mounts_config(self, tmp_path):
-        """Claude config is mounted: .claude.json as temp copy with bypass flag, .claude dir read-write."""
+        """Claude auth files are staged into a temp dir and mounted as /tmp/staging:ro."""
         claude_json = tmp_path / ".claude.json"
         claude_json.write_text("{}")
         claude_dir = tmp_path / ".claude"
@@ -147,19 +147,18 @@ class TestBuildDockerCmd:
             cmd = self._build(cli_tool="claude")
 
         vol_args = [cmd[i + 1] for i, x in enumerate(cmd) if x == "-v"]
-        json_vols = [v for v in vol_args if ".claude.json" in v]
-        dir_vols = [v for v in vol_args if ".claude" in v and ".claude.json" not in v]
-        # .claude.json is a temp copy (not the original) — mounted without :ro
-        assert len(json_vols) == 1, f"Expected one .claude.json mount, got: {json_vols}"
-        assert ":/home/worker/.claude.json" in json_vols[0]
-        # The temp copy should NOT be the original file
-        assert str(tmp_path / ".claude.json") not in json_vols[0].split(":")[0]
-        assert all(not v.endswith(":ro") for v in dir_vols), (
-            f".claude dir should be read-write for session data, got: {dir_vols}"
-        )
+        # Staging dir is mounted read-only at /tmp/staging
+        staging_vols = [v for v in vol_args if ":/tmp/staging:ro" in v]
+        assert len(staging_vols) == 1, f"Expected one staging mount at /tmp/staging:ro, got: {vol_args}"
+        # The original .claude.json should NOT be mounted directly
+        direct_json_vols = [v for v in vol_args if ":/home/worker/.claude.json" in v]
+        assert len(direct_json_vols) == 0, f"Expected no direct .claude.json mount, got: {direct_json_vols}"
+        # Staging dir must exist and contain .claude.json
+        staging_host = Path(staging_vols[0].split(":")[0])
+        assert (staging_host / ".claude.json").exists()
 
     def test_claude_json_has_bypass_flag(self, tmp_path):
-        """Temp .claude.json copy has bypassPermissionsModeAccepted=true."""
+        """Staged .claude.json copy has bypassPermissionsModeAccepted=true."""
         claude_json = tmp_path / ".claude.json"
         claude_json.write_text('{"projects": {}}')
         claude_dir = tmp_path / ".claude"
@@ -169,10 +168,9 @@ class TestBuildDockerCmd:
             cmd = self._build(cli_tool="claude")
 
         vol_args = [cmd[i + 1] for i, x in enumerate(cmd) if x == "-v"]
-        json_vols = [v for v in vol_args if ".claude.json" in v]
-        # Read the temp file to verify bypass flag was injected
-        tmp_file = json_vols[0].split(":")[0]
-        with open(tmp_file) as f:
+        staging_vols = [v for v in vol_args if ":/tmp/staging:ro" in v]
+        staging_host = Path(staging_vols[0].split(":")[0])
+        with open(staging_host / ".claude.json") as f:
             config = json.load(f)
         assert config["bypassPermissionsModeAccepted"] is True
         assert config["projects"] == {}

--- a/tests/polecat/test_cli_docker.py
+++ b/tests/polecat/test_cli_docker.py
@@ -149,10 +149,14 @@ class TestBuildDockerCmd:
         vol_args = [cmd[i + 1] for i, x in enumerate(cmd) if x == "-v"]
         # Staging dir is mounted read-only at /tmp/staging
         staging_vols = [v for v in vol_args if ":/tmp/staging:ro" in v]
-        assert len(staging_vols) == 1, f"Expected one staging mount at /tmp/staging:ro, got: {vol_args}"
+        assert len(staging_vols) == 1, (
+            f"Expected one staging mount at /tmp/staging:ro, got: {vol_args}"
+        )
         # The original .claude.json should NOT be mounted directly
         direct_json_vols = [v for v in vol_args if ":/home/worker/.claude.json" in v]
-        assert len(direct_json_vols) == 0, f"Expected no direct .claude.json mount, got: {direct_json_vols}"
+        assert len(direct_json_vols) == 0, (
+            f"Expected no direct .claude.json mount, got: {direct_json_vols}"
+        )
         # Staging dir must exist and contain .claude.json
         staging_host = Path(staging_vols[0].split(":")[0])
         assert (staging_host / ".claude.json").exists()


### PR DESCRIPTION
## Summary
- Docker/runc on macOS (Colima with sshfs or virtiofs) cannot bind-mount individual files — they silently become directories
- macOS VMs only share `/Users`, so temp files in `/var/folders` are invisible to Docker
- Stage auth files into `~/.aops/tmp/staging-<pid>/`, mount as directory, entrypoint copies into `$HOME`
- Remove baked-in `.claude.json` from image so copy creates it with correct UID ownership

## Test plan
- [x] `docker run` with staging dir mount successfully reads `.claude.json`
- [ ] `pc crew bm` launches Claude session without mount errors
- [ ] Auth credentials (`.credentials.json`) available inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)