### PR TITLE
Test/crew container e2e

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,17 @@ RUN claude plugin marketplace add /app \
 RUN mkdir -p /home/worker/.gemini \
     && GEMINI_API_KEY=dummy-for-install gemini extensions install /app/dist/aops-gemini --consent
 
+# Set permissive extension enablement so hooks fire for any workspace path.
+# `gemini extensions install` restricts to /home/<user>/* which doesn't match
+# mounted worktrees (e.g. /workspace, /data, or deeply nested crew paths).
+RUN if [ -f /home/worker/.gemini/extensions/extension-enablement.json ]; then \
+    python3 -c "import json, pathlib; \
+p = pathlib.Path('/home/worker/.gemini/extensions/extension-enablement.json'); \
+d = json.loads(p.read_text()); \
+[d.__setitem__(k, {**v, 'overrides': ['*']}) for k, v in d.items()]; \
+p.write_text(json.dumps(d, indent=2))" ; \
+    fi
+
 # Install default ccstatusline and Claude Code settings.
 # These defaults are overridden at runtime if the host stages replacements.
 COPY --chown=worker:worker polecat/defaults/ccstatusline-settings.json /home/worker/.config/ccstatusline/settings.json

--- a/aops-core/skills/butler/references/hooks.md
+++ b/aops-core/skills/butler/references/hooks.md
@@ -386,27 +386,29 @@ The SessionStart hook script can then load external instruction files into conte
 
 ## Gemini CLI compatibility and differences
 
-Gemini CLI **does not currently have a SessionStart hook system**. This is a fundamental architectural difference and the most significant compatibility gap. GitHub issues #2779 and #9070 track feature requests for hooks in Gemini CLI, with #9070 proposing a comprehensive design that would mirror Claude Code's JSON-over-stdin contract and exit code semantics, including migration tooling to convert Claude Code hooks. As of October 2025, this remains unimplemented.
+Gemini CLI **now supports hooks** via extensions and user/project settings. The hook system was implemented after v0.30 and supports 11 lifecycle events: `SessionStart`, `SessionEnd`, `BeforeAgent`, `AfterAgent`, `BeforeTool`, `AfterTool`, `BeforeModel`, `AfterModel`, `BeforeToolSelection`, `PreCompress`, and `Notification`.
+
+Extension hooks are defined in `<extension>/hooks/hooks.json` and are auto-discovered. User/project hooks go in `settings.json` under the `hooks` key. Hooks are enabled by default (`hooksConfig.enabled: true`).
 
 **Configuration comparison:**
 
-| Aspect                   | Claude Code CLI                                      | Gemini CLI                            |
-| ------------------------ | ---------------------------------------------------- | ------------------------------------- |
-| **Hooks system**         | 8 lifecycle events implemented                       | Not implemented (requested)           |
-| **SessionStart**         | Fully functional                                     | Not available                         |
-| **Configuration file**   | `~/.claude/settings.json`                            | `~/.gemini/settings.json`             |
-| **Context/memory**       | `CLAUDE.md`                                          | `GEMINI.md`                           |
-| **MCP servers**          | Separate `.mcp.json` (git-friendly)                  | In main settings.json                 |
-| **Discovery precedence** | Enterprise → Project local → Project → User → Legacy | System → User → Project → Environment |
-| **Philosophy**           | Hybrid deterministic + probabilistic                 | Purely probabilistic context-driven   |
+| Aspect                   | Claude Code CLI                     | Gemini CLI                                         |
+| ------------------------ | ----------------------------------- | -------------------------------------------------- |
+| **Hooks system**         | 10 lifecycle events                 | 11 lifecycle events (includes BeforeToolSelection) |
+| **Extension hooks**      | `hooks` in plugin settings          | `hooks/hooks.json` in extension directory          |
+| **Hook priority**        | Merged by settings hierarchy        | Runtime > Project > User > System > Extension      |
+| **Configuration file**   | `~/.claude/settings.json`           | `~/.gemini/settings.json`                          |
+| **Context/memory**       | `CLAUDE.md`                         | `GEMINI.md`                                        |
+| **MCP servers**          | Separate `.mcp.json` (git-friendly) | In `gemini-extension.json` or settings             |
+| **Path variable**        | `${CLAUDE_PLUGIN_ROOT}`             | `${extensionPath}`                                 |
+| **Sandbox scope**        | N/A (uses Docker via polecat)       | Tool subprocesses only; hooks run outside sandbox  |
+| **Extension enablement** | Plugin marketplace                  | `extension-enablement.json` with path overrides    |
 
-Gemini CLI relies entirely on **probabilistic AI following instructions** in GEMINI.md files rather than guaranteed deterministic hook execution. This makes it suitable for exploratory work and individual development but less reliable for production automation requiring guaranteed actions like formatting, linting, or quality gates.
+**Important**: When using `GEMINI_CLI_HOME` to redirect Gemini's config directory (as polecat crew does), the `settings.json` must not set `security.auth.selectedType` — Gemini exits before hooks fire if the auth type doesn't match available credentials. Let Gemini auto-detect. Similarly, `tools.sandbox.enabled: true` in settings can cause Gemini to crash writing state files to the temp directory. The safe template is `{"hooksConfig":{"enabled":true}}`.
 
 **Both CLIs can coexist** on the same system without conflicts—they use different configuration directories (`~/.claude/` vs `~/.gemini/`), different context files, and different command namespaces. MCP servers are fully compatible since both implement the Model Context Protocol standard; the same server works with both CLIs despite different configuration formats.
 
-**Migration path**: Currently manual. When Gemini implements hooks, the proposed design includes a `gemini hooks migrate --from-claude` command for automatic conversion of hook configurations and environment variable mappings.
-
-**When to use each**: Choose Claude Code for production environments requiring deterministic automation, team collaboration with shared configurations, CI/CD integration, and quality gate enforcement. Choose Gemini CLI for exploratory development, personal projects, situations where the generous free tier matters, or when you prefer open-source tools (Gemini CLI is Apache 2.0 licensed). The fundamental trade-off is deterministic control vs. probabilistic instruction-following.
+**Migration path**: `gemini hooks migrate --from-claude` converts Claude Code hook configurations to Gemini CLI format.
 
 ## Known limitations and issues
 

--- a/dist/aops-claude/skills/butler/enforcement-map.md
+++ b/dist/aops-claude/skills/butler/enforcement-map.md
@@ -199,10 +199,10 @@ Context loading follows a **three-tier architecture** (see [[session-start-injec
 
 ### File Loading Summary
 
-| File                        | Purpose                           | Loaded Via                    |
-| --------------------------- | --------------------------------- | ----------------------------- |
-| `$AOPS/CORE.md`             | Framework tool inventory (~2KB)   | SessionStart hook             |
-| `$cwd/.agent/CORE.md`       | Project conventions               | SessionStart hook (if exists) |
+| File                              | Purpose                           | Loaded Via                    |
+| --------------------------------- | --------------------------------- | ----------------------------- |
+| `$AOPS/CORE.md`                   | Framework tool inventory (~2KB)   | SessionStart hook             |
+| `$cwd/.agent/CORE.md`             | Project conventions               | SessionStart hook (if exists) |
 | `$AOPS/AXIOMS.md`                 | Tier 1: Universal axioms          | SessionStart (always)         |
 | `$AOPS/RULES-DEV.md`              | Tier 2: Development context rules | JIT (when writing code)       |
 | `$AOPS/RULES-FRAMEWORK.md`        | Tier 2: Framework context rules   | JIT (when on framework work)  |

--- a/dist/aops-claude/skills/butler/references/hooks.md
+++ b/dist/aops-claude/skills/butler/references/hooks.md
@@ -386,27 +386,29 @@ The SessionStart hook script can then load external instruction files into conte
 
 ## Gemini CLI compatibility and differences
 
-Gemini CLI **does not currently have a SessionStart hook system**. This is a fundamental architectural difference and the most significant compatibility gap. GitHub issues #2779 and #9070 track feature requests for hooks in Gemini CLI, with #9070 proposing a comprehensive design that would mirror Claude Code's JSON-over-stdin contract and exit code semantics, including migration tooling to convert Claude Code hooks. As of October 2025, this remains unimplemented.
+Gemini CLI **now supports hooks** via extensions and user/project settings. The hook system was implemented after v0.30 and supports 11 lifecycle events: `SessionStart`, `SessionEnd`, `BeforeAgent`, `AfterAgent`, `BeforeTool`, `AfterTool`, `BeforeModel`, `AfterModel`, `BeforeToolSelection`, `PreCompress`, and `Notification`.
+
+Extension hooks are defined in `<extension>/hooks/hooks.json` and are auto-discovered. User/project hooks go in `settings.json` under the `hooks` key. Hooks are enabled by default (`hooksConfig.enabled: true`).
 
 **Configuration comparison:**
 
-| Aspect                   | Claude Code CLI                                      | Gemini CLI                            |
-| ------------------------ | ---------------------------------------------------- | ------------------------------------- |
-| **Hooks system**         | 8 lifecycle events implemented                       | Not implemented (requested)           |
-| **SessionStart**         | Fully functional                                     | Not available                         |
-| **Configuration file**   | `~/.claude/settings.json`                            | `~/.gemini/settings.json`             |
-| **Context/memory**       | `CLAUDE.md`                                          | `GEMINI.md`                           |
-| **MCP servers**          | Separate `.mcp.json` (git-friendly)                  | In main settings.json                 |
-| **Discovery precedence** | Enterprise → Project local → Project → User → Legacy | System → User → Project → Environment |
-| **Philosophy**           | Hybrid deterministic + probabilistic                 | Purely probabilistic context-driven   |
+| Aspect                   | Claude Code CLI                     | Gemini CLI                                         |
+| ------------------------ | ----------------------------------- | -------------------------------------------------- |
+| **Hooks system**         | 10 lifecycle events                 | 11 lifecycle events (includes BeforeToolSelection) |
+| **Extension hooks**      | `hooks` in plugin settings          | `hooks/hooks.json` in extension directory          |
+| **Hook priority**        | Merged by settings hierarchy        | Runtime > Project > User > System > Extension      |
+| **Configuration file**   | `~/.claude/settings.json`           | `~/.gemini/settings.json`                          |
+| **Context/memory**       | `CLAUDE.md`                         | `GEMINI.md`                                        |
+| **MCP servers**          | Separate `.mcp.json` (git-friendly) | In `gemini-extension.json` or settings             |
+| **Path variable**        | `${CLAUDE_PLUGIN_ROOT}`             | `${extensionPath}`                                 |
+| **Sandbox scope**        | N/A (uses Docker via polecat)       | Tool subprocesses only; hooks run outside sandbox  |
+| **Extension enablement** | Plugin marketplace                  | `extension-enablement.json` with path overrides    |
 
-Gemini CLI relies entirely on **probabilistic AI following instructions** in GEMINI.md files rather than guaranteed deterministic hook execution. This makes it suitable for exploratory work and individual development but less reliable for production automation requiring guaranteed actions like formatting, linting, or quality gates.
+**Important**: Extension hooks only fire when `extension.isActive` is true for the current workspace. Activity is controlled by `extension-enablement.json` overrides. The default override (`/home/<user>/*`) uses single-level glob matching, which may not cover deeply nested worktree paths or mounted directories. Set overrides to `["*"]` for universal activation.
 
 **Both CLIs can coexist** on the same system without conflicts—they use different configuration directories (`~/.claude/` vs `~/.gemini/`), different context files, and different command namespaces. MCP servers are fully compatible since both implement the Model Context Protocol standard; the same server works with both CLIs despite different configuration formats.
 
-**Migration path**: Currently manual. When Gemini implements hooks, the proposed design includes a `gemini hooks migrate --from-claude` command for automatic conversion of hook configurations and environment variable mappings.
-
-**When to use each**: Choose Claude Code for production environments requiring deterministic automation, team collaboration with shared configurations, CI/CD integration, and quality gate enforcement. Choose Gemini CLI for exploratory development, personal projects, situations where the generous free tier matters, or when you prefer open-source tools (Gemini CLI is Apache 2.0 licensed). The fundamental trade-off is deterministic control vs. probabilistic instruction-following.
+**Migration path**: `gemini hooks migrate --from-claude` converts Claude Code hook configurations to Gemini CLI format.
 
 ## Known limitations and issues
 

--- a/polecat/cli.py
+++ b/polecat/cli.py
@@ -16,11 +16,10 @@ if str(REPO_ROOT / "aops-core") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "aops-core"))
 
 import click
+from lib.agent_env import apply_env_mappings
 from manager import PolecatManager
 from observability import metrics
 from validation import TaskIDValidationError, validate_task_id_or_raise
-
-from lib.agent_env import apply_env_mappings
 
 # Max turns for headless Claude runs — must be high enough to accommodate hook
 # overhead (hydration gate, custodiet compliance check) plus actual task work.

--- a/polecat/cli.py
+++ b/polecat/cli.py
@@ -16,10 +16,11 @@ if str(REPO_ROOT / "aops-core") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "aops-core"))
 
 import click
-from lib.agent_env import apply_env_mappings
 from manager import PolecatManager
 from observability import metrics
 from validation import TaskIDValidationError, validate_task_id_or_raise
+
+from lib.agent_env import apply_env_mappings
 
 # Max turns for headless Claude runs — must be high enough to accommodate hook
 # overhead (hydration gate, custodiet compliance check) plus actual task work.
@@ -543,6 +544,7 @@ def _replicate_gemini_auth(env: dict, work_dir: Path | None = None) -> Path | No
         "settings.json",
         "google_accounts.json",
         "oauth_creds.json",
+        "gemini-credentials.json",
         "installation_id",
         "trustedFolders.json",
         "projects.json",

--- a/polecat/cli.py
+++ b/polecat/cli.py
@@ -16,10 +16,11 @@ if str(REPO_ROOT / "aops-core") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "aops-core"))
 
 import click
-from lib.agent_env import apply_env_mappings
 from manager import PolecatManager
 from observability import metrics
 from validation import TaskIDValidationError, validate_task_id_or_raise
+
+from lib.agent_env import apply_env_mappings
 
 # Max turns for headless Claude runs — must be high enough to accommodate hook
 # overhead (hydration gate, custodiet compliance check) plus actual task work.
@@ -580,30 +581,21 @@ def _replicate_gemini_auth(env: dict, work_dir: Path | None = None) -> Path | No
 
         if f == "settings.json":
             try:
-                # Read only the auth type from the user's settings — everything
-                # else comes from our controlled template to avoid leaking user
-                # baggage (MCP servers, hooks, UI prefs) into sandbox sessions.
-                with open(gemini_dir / f) as src_f:
-                    user_settings = json.load(src_f)
-                auth_type = user_settings.get("security", {}).get("auth", {}).get("selectedType")
-                if not auth_type:
-                    print(
-                        "   Warning: no security.auth.selectedType in user settings.json — "
-                        "sandbox auth may fail",
-                        file=sys.stderr,
-                    )
-                    continue
-
+                # Use our controlled template WITHOUT the user's auth selectedType.
+                # Gemini CLI auto-detects auth from available credentials (API key env
+                # var, OAuth files, etc.). Injecting selectedType causes Gemini to exit
+                # immediately if the auth type doesn't match available credentials
+                # (e.g. user logged in via Google Account but crew session has API key),
+                # which prevents hooks from firing at all.
                 template_path = SCRIPT_DIR / "defaults" / "gemini-settings.json"
                 with open(template_path) as tpl_f:
                     minimal = json.load(tpl_f)
-                minimal["security"]["auth"]["selectedType"] = auth_type
 
                 with open(target_dir / f, "w") as dst_f:
                     json.dump(minimal, dst_f, indent=2)
                 continue
             except (json.JSONDecodeError, OSError) as e:
-                print(f"   Warning: could not process user settings.json: {e}", file=sys.stderr)
+                print(f"   Warning: could not process settings.json template: {e}", file=sys.stderr)
                 continue
 
         # Follow symlinks to copy the actual file content, not the link itself.

--- a/polecat/defaults/gemini-settings.json
+++ b/polecat/defaults/gemini-settings.json
@@ -1,13 +1,5 @@
 {
-  "security": {
-    "auth": {
-      "selectedType": "__AUTH_TYPE__"
-    }
-  },
-  "tools": {
-    "sandbox": {
-      "enabled": true,
-      "networkAccess": true
-    }
+  "hooksConfig": {
+    "enabled": true
   }
 }

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -5,6 +5,7 @@ Replaces setup.sh logic.
 """
 
 import argparse
+import json
 import os
 import shutil
 import subprocess
@@ -329,6 +330,19 @@ def main():
                 ],
                 check=False,
             )
+            # Set permissive extension enablement so hooks fire for any workspace path.
+            # `gemini extensions link` restricts overrides to /home/<user>/* which doesn't
+            # match mounted worktrees or deeply nested crew paths.
+            enablement_path = Path.home() / ".gemini" / "extensions" / "extension-enablement.json"
+            if enablement_path.exists():
+                try:
+                    enablement = json.loads(enablement_path.read_text())
+                    for ext_name in enablement:
+                        enablement[ext_name]["overrides"] = ["*"]
+                    enablement_path.write_text(json.dumps(enablement, indent=2))
+                    print("✓ Set permissive extension enablement for hooks")
+                except (json.JSONDecodeError, OSError) as e:
+                    print(f"Warning: could not update extension enablement: {e}")
         else:
             print("Warning: Gemini extension dist not found. Skipping link.")
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,6 +175,19 @@ def gemini_home(tmp_path_factory) -> Path:
             f"Failed to link Gemini extension (exit {result.returncode}). Stderr: {result.stderr}"
         )
 
+    # 4. Set permissive extension enablement so hooks fire for any workspace path.
+    # `gemini extensions link` restricts overrides to /home/<user>/* which won't
+    # match test tmp dirs, crew worktrees, or CI workspaces.
+    enablement_path = ext_dir / "extension-enablement.json"
+    if enablement_path.exists():
+        try:
+            enablement = json.loads(enablement_path.read_text())
+            for ext_name in enablement:
+                enablement[ext_name]["overrides"] = ["*"]
+            enablement_path.write_text(json.dumps(enablement, indent=2))
+        except (json.JSONDecodeError, OSError):
+            pass  # Best effort — test will fail downstream if this matters
+
     return tmp_home
 
 
@@ -378,6 +391,7 @@ Provides:
 from pathlib import Path
 
 import pytest
+
 from lib.paths import get_plugin_root as get_aops_root
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -391,7 +391,6 @@ Provides:
 from pathlib import Path
 
 import pytest
-
 from lib.paths import get_plugin_root as get_aops_root
 
 

--- a/tests/e2e/test_gemini_hooks_fire.py
+++ b/tests/e2e/test_gemini_hooks_fire.py
@@ -27,10 +27,16 @@ class TestGeminiHooksFire:
         if not shutil.which("gemini"):
             pytest.skip("gemini CLI not in PATH")
 
-        # Verify extension is installed
+        # Verify extension is installed with Gemini-format hooks
         ext_dir = Path.home() / ".gemini" / "extensions" / "aops-core"
         if not ext_dir.exists():
             pytest.skip("aops-core extension not installed")
+        hooks_json = ext_dir / "hooks" / "hooks.json"
+        if not hooks_json.exists():
+            pytest.skip(
+                "aops-core extension has no hooks/hooks.json — "
+                "installed from repo root instead of dist/aops-gemini?"
+            )
 
         tmp_path = tmp_path_factory.mktemp("gemini_hooks")
         sessions_dir = tmp_path / "hook-sessions"
@@ -120,6 +126,12 @@ class TestGeminiHooksWithSettings:
         ext_dir = Path.home() / ".gemini" / "extensions" / "aops-core"
         if not ext_dir.exists():
             pytest.skip("aops-core extension not installed")
+        hooks_json = ext_dir / "hooks" / "hooks.json"
+        if not hooks_json.exists():
+            pytest.skip(
+                "aops-core extension has no hooks/hooks.json — "
+                "installed from repo root instead of dist/aops-gemini?"
+            )
 
         tmp_path = tmp_path_factory.mktemp("gemini_settings")
         sessions_dir = tmp_path / "sessions"

--- a/tests/e2e/test_gemini_hooks_fire.py
+++ b/tests/e2e/test_gemini_hooks_fire.py
@@ -1,0 +1,202 @@
+"""E2E: verify Gemini CLI fires our extension hooks.
+
+Gemini fires lifecycle hooks (SessionStart, SessionEnd) before auth
+completes, so we can test with a dummy API key — no real credentials
+needed. The assertion: did our hook log get written with a SessionStart
+entry? If yes, the entire chain worked end-to-end through Gemini CLI.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.integration
+class TestGeminiHooksFire:
+    """End-to-end: Gemini CLI fires our extension hooks."""
+
+    @pytest.fixture(scope="class")
+    def gemini_session(self, tmp_path_factory):
+        """Run Gemini CLI with dummy auth, return hook log entries and stderr."""
+        if not shutil.which("gemini"):
+            pytest.skip("gemini CLI not in PATH")
+
+        # Verify extension is installed
+        ext_dir = Path.home() / ".gemini" / "extensions" / "aops-core"
+        if not ext_dir.exists():
+            pytest.skip("aops-core extension not installed")
+
+        tmp_path = tmp_path_factory.mktemp("gemini_hooks")
+        sessions_dir = tmp_path / "hook-sessions"
+        sessions_dir.mkdir()
+
+        env = os.environ.copy()
+        env["GEMINI_API_KEY"] = "dummy-no-auth-needed-for-hook-test"
+        env["AOPS_SESSIONS"] = str(sessions_dir)
+        env["AOPS"] = str(REPO_ROOT)
+        env["CLAUDE_PLUGIN_ROOT"] = str(REPO_ROOT / "aops-core")
+        env.pop("NTFY_TOPIC", None)
+
+        result = subprocess.run(
+            ["gemini", "-p", "test"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+            cwd=tmp_path,
+        )
+
+        # Parse hook log entries
+        entries = []
+        for log_file in sessions_dir.rglob("*-hooks.jsonl"):
+            for line in log_file.read_text().splitlines():
+                if line.strip():
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+
+        return {
+            "entries": entries,
+            "events": [e.get("hook_event") for e in entries],
+            "stderr": result.stderr,
+            "stdout": result.stdout,
+            "returncode": result.returncode,
+            "sessions_dir": sessions_dir,
+        }
+
+    def test_session_start_hook_fires(self, gemini_session):
+        """Gemini must fire our SessionStart hook and produce a log entry."""
+        assert "SessionStart" in gemini_session["events"], (
+            f"SessionStart hook did not fire through Gemini CLI.\n"
+            f"Events logged: {gemini_session['events']}\n"
+            f"Hook logs: {list(gemini_session['sessions_dir'].rglob('*.jsonl'))}\n"
+            f"stderr (last 500): {gemini_session['stderr'][-500:]}\n"
+            f"stdout (last 200): {gemini_session['stdout'][-200:]}"
+        )
+
+    def test_hook_log_has_session_id(self, gemini_session):
+        """Hook log entries must have a session ID assigned by the router."""
+        starts = [e for e in gemini_session["entries"] if e.get("hook_event") == "SessionStart"]
+        if not starts:
+            pytest.skip("SessionStart didn't fire")
+        session_id = starts[0].get("session_id", "")
+        assert session_id and session_id != "unknown", (
+            f"SessionStart entry has no valid session_id: {starts[0]}"
+        )
+
+    def test_hook_output_has_decision(self, gemini_session):
+        """Hook output must contain a verdict that Gemini can act on."""
+        starts = [e for e in gemini_session["entries"] if e.get("hook_event") == "SessionStart"]
+        if not starts:
+            pytest.skip("SessionStart didn't fire")
+        output = starts[0].get("output", {})
+        assert output.get("verdict") in ("allow", "deny"), (
+            f"SessionStart output missing valid verdict: {output}"
+        )
+
+
+@pytest.mark.integration
+class TestGeminiHooksWithSettings:
+    """Verify hooks still fire when settings.json exists.
+
+    Regression test for the polecat/crew bug: writing a settings.json
+    with security.auth.selectedType caused Gemini to exit before hooks
+    fired. This test proves hooks survive a settings.json.
+    """
+
+    @pytest.fixture(scope="class")
+    def gemini_session_with_settings(self, tmp_path_factory):
+        """Run Gemini with a GEMINI_CLI_HOME that has a settings.json."""
+        if not shutil.which("gemini"):
+            pytest.skip("gemini CLI not in PATH")
+
+        ext_dir = Path.home() / ".gemini" / "extensions" / "aops-core"
+        if not ext_dir.exists():
+            pytest.skip("aops-core extension not installed")
+
+        tmp_path = tmp_path_factory.mktemp("gemini_settings")
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+
+        # Simulate polecat crew: custom GEMINI_CLI_HOME with settings + extensions
+        gemini_home = tmp_path / "gemini-home"
+        gemini_home.mkdir()
+        dot_gemini = gemini_home / ".gemini"
+        dot_gemini.mkdir()
+
+        # Copy extensions from system install
+        shutil.copytree(
+            Path.home() / ".gemini" / "extensions",
+            dot_gemini / "extensions",
+        )
+
+        # Copy state files Gemini CLI needs for project registry
+        for f in (
+            "extension_integrity.json",
+            "projects.json",
+            "gemini-credentials.json",
+            "state.json",
+        ):
+            src = Path.home() / ".gemini" / f
+            if src.exists():
+                shutil.copy2(src, dot_gemini / f)
+
+        # Write the polecat template settings (the thing that used to break hooks)
+        template = REPO_ROOT / "polecat" / "defaults" / "gemini-settings.json"
+        shutil.copy2(template, dot_gemini / "settings.json")
+
+        env = os.environ.copy()
+        env["GEMINI_API_KEY"] = "dummy-no-auth-needed"
+        env["GEMINI_CLI_HOME"] = str(gemini_home)
+        env["AOPS_SESSIONS"] = str(sessions_dir)
+        env["AOPS"] = str(REPO_ROOT)
+        env["CLAUDE_PLUGIN_ROOT"] = str(REPO_ROOT / "aops-core")
+        env.pop("NTFY_TOPIC", None)
+
+        result = subprocess.run(
+            ["gemini", "-p", "test"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+            cwd=tmp_path,
+        )
+
+        entries = []
+        for log_file in sessions_dir.rglob("*-hooks.jsonl"):
+            for line in log_file.read_text().splitlines():
+                if line.strip():
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+
+        return {
+            "entries": entries,
+            "events": [e.get("hook_event") for e in entries],
+            "stderr": result.stderr,
+            "stdout": result.stdout,
+            "settings_json": (dot_gemini / "settings.json").read_text(),
+        }
+
+    def test_hooks_fire_with_polecat_settings(self, gemini_session_with_settings):
+        """Hooks must fire even with the polecat settings.json template.
+
+        This is the exact regression that caused the original bug: polecat
+        wrote a settings.json with selectedType, Gemini exited on auth
+        mismatch before hooks fired.
+        """
+        sess = gemini_session_with_settings
+        assert "SessionStart" in sess["events"], (
+            f"Hooks did not fire with polecat settings template.\n"
+            f"settings.json: {sess['settings_json']}\n"
+            f"stderr (last 500): {sess['stderr'][-500:]}\n"
+            f"stdout (last 200): {sess['stdout'][-200:]}"
+        )

--- a/tests/e2e/test_polecat_docker_isolation.py
+++ b/tests/e2e/test_polecat_docker_isolation.py
@@ -51,7 +51,9 @@ def _crew_env(polecat_home):
     env["POLECAT_HOME"] = str(polecat_home)
     # PYTHONPATH must include the repo root (not polecat/ itself) so that
     # `python -m polecat.cli` can resolve `polecat` as a package.
-    env["PYTHONPATH"] = os.getcwd() + ":" + os.getcwd() + "/aops-core"
+    env["PYTHONPATH"] = (
+        os.getcwd() + ":" + os.getcwd() + "/polecat" + ":" + os.getcwd() + "/aops-core"
+    )
     return env
 
 
@@ -120,8 +122,8 @@ def test_crew_spawns_docker_container_gemini(temp_polecat_home, tmp_path):
     subprocess.run(["git", "commit", "--allow-empty", "-m", "init"], cwd=repo, check=True)
 
     # We write a fake 'gemini' executable in our PATH to intercept the call.
-    # Polecat crew now configures sandbox via settings.json (not --sandbox flag),
-    # so the fake gemini just needs to succeed — we verify settings.json afterwards.
+    # Polecat crew configures hooks via the replicated settings.json template.
+    # The fake gemini dumps settings.json to stdout before polecat cleans up the temp dir.
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_gemini = fake_bin / "gemini"
@@ -130,6 +132,11 @@ def test_crew_spawns_docker_container_gemini(temp_polecat_home, tmp_path):
         'echo "GEMINI_SANDBOX_IMAGE=${GEMINI_SANDBOX_IMAGE:-}"\n'
         'echo "GEMINI_CLI_HOME=${GEMINI_CLI_HOME:-}"\n'
         "echo 'ARGS:' $@\n"
+        'if [ -f "${GEMINI_CLI_HOME}/.gemini/settings.json" ]; then\n'
+        '  echo "SETTINGS_JSON_BEGIN"\n'
+        '  cat "${GEMINI_CLI_HOME}/.gemini/settings.json"\n'
+        '  echo "SETTINGS_JSON_END"\n'
+        "fi\n"
     )
     fake_gemini.chmod(0o755)
 
@@ -160,19 +167,16 @@ def test_crew_spawns_docker_container_gemini(temp_polecat_home, tmp_path):
         "Should set GEMINI_SANDBOX_IMAGE for gemini CLI"
     )
 
-    # Sandbox is now configured via settings.json, not --sandbox flag.
-    # Verify the replicated gemini home has sandbox enabled in settings.
-    # The fake gemini prints all GEMINI_* env vars — GEMINI_CLI_HOME tells us where to look.
-    gemini_home_match = re.search(r"GEMINI_CLI_HOME=(.*)", output)
-    assert gemini_home_match, f"GEMINI_CLI_HOME not found in output:\n{output}"
-    settings_path = Path(gemini_home_match.group(1).strip()) / "settings.json"
-    assert settings_path.exists(), f"settings.json not found at {settings_path}"
-    import json
-
-    settings = json.loads(settings_path.read_text())
-    sandbox_cfg = settings.get("tools", {}).get("sandbox", {})
-    assert sandbox_cfg.get("enabled") is True, (
-        f"Sandbox should be enabled in settings.json. Got: {sandbox_cfg}"
+    # Verify the replicated settings.json has hooksConfig enabled.
+    # The fake gemini dumps settings.json to stdout before polecat cleans up the temp dir.
+    assert "SETTINGS_JSON_BEGIN" in output, (
+        f"settings.json not dumped by fake gemini. Output:\n{output}"
+    )
+    settings_raw = output.split("SETTINGS_JSON_BEGIN")[1].split("SETTINGS_JSON_END")[0].strip()
+    settings = json.loads(settings_raw)
+    hooks_cfg = settings.get("hooksConfig", {})
+    assert hooks_cfg.get("enabled") is True, (
+        f"hooksConfig should be enabled in settings.json. Got: {hooks_cfg}"
     )
 
 
@@ -596,15 +600,16 @@ def test_crew_gemini_sandbox_config(temp_polecat_home, tmp_path):
     settings_raw = output.split("SETTINGS_JSON_BEGIN")[1].split("SETTINGS_JSON_END")[0].strip()
     settings = json.loads(settings_raw)
 
-    sandbox_cfg = settings.get("tools", {}).get("sandbox", {})
-    assert sandbox_cfg.get("enabled") is True, f"Sandbox not enabled. Got: {sandbox_cfg}"
-    assert sandbox_cfg.get("networkAccess") is True, (
-        f"networkAccess not enabled (needed for OAuth). Got: {sandbox_cfg}"
-    )
+    hooks_cfg = settings.get("hooksConfig", {})
+    assert hooks_cfg.get("enabled") is True, f"hooksConfig not enabled. Got: {hooks_cfg}"
 
     # No user baggage leaked
     assert "mcpServers" not in settings, (
         f"mcpServers leaked into sandbox settings: {list(settings.get('mcpServers', {}).keys())}"
+    )
+    # Auth selectedType must NOT be injected (causes Gemini to exit before hooks fire)
+    assert "selectedType" not in settings.get("security", {}).get("auth", {}), (
+        "selectedType leaked into sandbox settings — this breaks Gemini auth detection"
     )
 
     # 3. Token embedded in .gitconfig (not env var placeholder)
@@ -615,7 +620,9 @@ def test_crew_gemini_sandbox_config(temp_polecat_home, tmp_path):
             return ""
         return out.split(begin, 1)[1].split(end, 1)[0].strip()
 
-    gitconfig_content = extract_mount_content(output, str(Path.home() / ".gitconfig"))
+    # Use fake_home (not Path.home()) because the subprocess runs with HOME=fake_home,
+    # so mount destinations use the subprocess's home path.
+    gitconfig_content = extract_mount_content(output, str(fake_home / ".gitconfig"))
     assert gitconfig_content, (
         ".gitconfig mount not found in sandbox output — token embedding is unverified. "
         "If apply_env_mappings() failed to map AOPS_BOT_GH_TOKEN to GH_TOKEN, "

--- a/tests/polecat/test_cli_docker.py
+++ b/tests/polecat/test_cli_docker.py
@@ -459,11 +459,12 @@ class TestReplicateGeminiAuth:
         shutil.rmtree(result)
 
     def test_replicated_settings_is_minimal(self, tmp_path):
-        """Replicated settings.json should contain only auth + sandbox config.
+        """Replicated settings.json uses controlled template, not user settings.
 
-        User baggage (MCP servers, UI prefs, hooks, shell config) must not leak
-        into sandbox sessions — it causes hangs, non-reproducible behavior, and
-        host-path references that don't exist inside the container.
+        User baggage (MCP servers, UI prefs, auth selectedType, shell config)
+        must not leak into sandbox sessions. The template provides only
+        hooksConfig.enabled — no auth type (let Gemini auto-detect), no sandbox
+        settings, no user preferences.
         """
         gemini_dir = tmp_path / ".gemini"
         gemini_dir.mkdir(parents=True)
@@ -486,27 +487,25 @@ class TestReplicateGeminiAuth:
         assert result is not None
         replicated = json.loads((result / ".gemini" / "settings.json").read_text())
 
-        # Auth config preserved
-        assert replicated["security"]["auth"]["selectedType"] == "oauth-personal"
-        # Sandbox forced on
-        assert replicated["tools"]["sandbox"]["enabled"] is True
-        assert replicated["tools"]["sandbox"]["networkAccess"] is True
+        # Hooks explicitly enabled
+        assert replicated["hooksConfig"]["enabled"] is True
+        # No auth selectedType (Gemini auto-detects — avoids auth mismatch crash)
+        assert "security" not in replicated
         # User baggage stripped
         assert "mcpServers" not in replicated
         assert "ui" not in replicated
         assert "hooks" not in replicated
-        assert "shell" not in replicated.get("tools", {})
 
         import shutil
 
         shutil.rmtree(result)
 
-    def test_missing_auth_type_skips_settings(self, tmp_path):
-        """Settings without security.auth.selectedType should be skipped, not defaulted."""
+    def test_missing_auth_type_still_writes_settings(self, tmp_path):
+        """Settings.json is always written from template, regardless of user settings."""
         gemini_dir = tmp_path / ".gemini"
         gemini_dir.mkdir(parents=True)
 
-        # Settings with no auth type
+        # Settings with no auth type — template should still be written
         (gemini_dir / "settings.json").write_text(json.dumps({"tools": {}}))
 
         env = {}
@@ -514,15 +513,17 @@ class TestReplicateGeminiAuth:
             result = _replicate_gemini_auth(env)
 
         assert result is not None
-        # settings.json should not exist — skipped due to missing auth type
-        assert not (result / ".gemini" / "settings.json").exists()
+        # settings.json should exist — written from template
+        assert (result / ".gemini" / "settings.json").exists()
+        replicated = json.loads((result / ".gemini" / "settings.json").read_text())
+        assert replicated["hooksConfig"]["enabled"] is True
 
         import shutil
 
         shutil.rmtree(result)
 
-    def test_corrupt_settings_skipped(self, tmp_path):
-        """Unparseable settings.json should be skipped, not copied raw."""
+    def test_corrupt_settings_still_writes_template(self, tmp_path):
+        """Even with corrupt user settings, template is written."""
         gemini_dir = tmp_path / ".gemini"
         gemini_dir.mkdir(parents=True)
 
@@ -533,8 +534,8 @@ class TestReplicateGeminiAuth:
             result = _replicate_gemini_auth(env)
 
         assert result is not None
-        # settings.json should not exist — skipped due to parse error
-        assert not (result / ".gemini" / "settings.json").exists()
+        # settings.json should exist — written from template (user settings irrelevant)
+        assert (result / ".gemini" / "settings.json").exists()
 
         import shutil
 


### PR DESCRIPTION
PR #379 is the Gemini auth fix and it never landed on main. Here's what it does:
                                                                                                                                                                   
  1. polecat/defaults/gemini-settings.json: Strips the security.auth.selectedType entirely — Gemini auto-detects auth. The old template injected selectedType which
   caused Gemini to exit immediately if auth type didn't match, preventing hooks from firing.
  2. polecat/cli.py: Stops injecting selectedType into the template. The comment explains: "Injecting selectedType causes Gemini to exit immediately if the auth   
  type doesn't match available credentials."                                                                                                                       
  3. Dockerfile: Fixes extension enablement so hooks fire for any workspace path (not just /home/<user>/*).
  4. test_gemini_hooks_fire.py: The regression test proving hooks fire with the template settings.                                                                 
                                                
PR #379 was merged 4 minutes after #377 was merged to main, so it went into a dead branch. The fix never landed.                   
                                                      