### PR TITLE
fix(merge-prep): re-qualify PRs when late reviews arrive after success

### DIFF
--- a/.github/workflows/merge-prep-cron.yml
+++ b/.github/workflows/merge-prep-cron.yml
@@ -140,8 +140,27 @@ jobs:
               2>/dev/null || echo "")
 
             if [ "$MP_STATUS" = "success" ]; then
-              echo "  SKIP: merge-prep-status is success (already processed)"
-              continue
+              # Check for CHANGES_REQUESTED reviews that arrived after merge-prep
+              # set success (race condition: Axiom Review triggered by merge-prep's
+              # own commits can finish after merge-prep declares success)
+              MP_CREATED=$(gh api "repos/$REPO/commits/$HEAD_SHA/statuses" \
+                --jq '[.[] | select(.context == "merge-prep-status" and .state == "success")] | sort_by(.created_at) | last | .created_at' \
+                2>/dev/null || echo "")
+
+              LATE_CR=0
+              if [ -n "$MP_CREATED" ]; then
+                JQ_FILTER="[.[] | select(.state == \"CHANGES_REQUESTED\" and .submitted_at > \"$MP_CREATED\")] | length"
+                LATE_CR=$(gh api "repos/$REPO/pulls/$PR_NUM/reviews" \
+                  --jq "$JQ_FILTER" \
+                  2>/dev/null || echo "0")
+              fi
+
+              if [ "$LATE_CR" -gt 0 ]; then
+                echo "  RE-QUALIFY: $LATE_CR CHANGES_REQUESTED review(s) arrived after merge-prep succeeded"
+              else
+                echo "  SKIP: merge-prep-status is success (already processed, no late reviews)"
+                continue
+              fi
             fi
 
             if [ "$MP_STATUS" = "failure" ]; then

--- a/aops-core/skills/supervisor/instructions/supervision-loop.md
+++ b/aops-core/skills/supervisor/instructions/supervision-loop.md
@@ -79,16 +79,16 @@ Note: the `dispatched` status in the local work items table maps to
 
 ### Work Item Statuses
 
-| Status          | Meaning                                                         |
-| --------------- | --------------------------------------------------------------- |
-| ready           | Decomposed, ready to dispatch                                   |
-| dispatched      | Sent to worker, waiting for PR                                  |
-| pr_open         | PR filed, under review                                          |
-| pr_approved     | Approved, ready to merge                                        |
-| done            | Merged and verified                                             |
-| blocked         | Waiting on a dependency — will be unblocked automatically       |
-| needs_decision  | Requires human judgment before work can proceed — do not dispatch |
-| failed          | Worker failed, needs re-dispatch or replan                      |
+| Status         | Meaning                                                           |
+| -------------- | ----------------------------------------------------------------- |
+| ready          | Decomposed, ready to dispatch                                     |
+| dispatched     | Sent to worker, waiting for PR                                    |
+| pr_open        | PR filed, under review                                            |
+| pr_approved    | Approved, ready to merge                                          |
+| done           | Merged and verified                                               |
+| blocked        | Waiting on a dependency — will be unblocked automatically         |
+| needs_decision | Requires human judgment before work can proceed — do not dispatch |
+| failed         | Worker failed, needs re-dispatch or replan                        |
 
 `needs_decision` maps to PKB task status `needs_review`. Agents cannot claim
 tasks in these statuses, so setting them is an enforceable gate — not an
@@ -159,13 +159,13 @@ No active polling loops. Check once per invocation.
 
 ### REACT
 
-| Problem                           | Response                                         |
-| --------------------------------- | ------------------------------------------------ |
-| Worker failed (no PR, task reset) | Re-dispatch, possibly different worker           |
-| PR has merge conflicts            | Close PR, re-dispatch on fresh base              |
-| PR got CHANGES_REQUESTED          | Read review comments, decide: fix or re-dispatch |
-| Task bigger than expected         | Decompose further, add work items                |
-| Dependency discovered             | Add depends_on, mark dependent as blocked        |
+| Problem                           | Response                                           |
+| --------------------------------- | -------------------------------------------------- |
+| Worker failed (no PR, task reset) | Re-dispatch, possibly different worker             |
+| PR has merge conflicts            | Close PR, re-dispatch on fresh base                |
+| PR got CHANGES_REQUESTED          | Read review comments, decide: fix or re-dispatch   |
+| Task bigger than expected         | Decompose further, add work items                  |
+| Dependency discovered             | Add depends_on, mark dependent as blocked          |
 | Academic integrity concern        | Set task status to `needs_review`, do not dispatch |
 
 ### INTEGRATE

--- a/dist/aops-claude/skills/supervisor/instructions/supervision-loop.md
+++ b/dist/aops-claude/skills/supervisor/instructions/supervision-loop.md
@@ -79,16 +79,16 @@ Note: the `dispatched` status in the local work items table maps to
 
 ### Work Item Statuses
 
-| Status          | Meaning                                                         |
-| --------------- | --------------------------------------------------------------- |
-| ready           | Decomposed, ready to dispatch                                   |
-| dispatched      | Sent to worker, waiting for PR                                  |
-| pr_open         | PR filed, under review                                          |
-| pr_approved     | Approved, ready to merge                                        |
-| done            | Merged and verified                                             |
-| blocked         | Waiting on a dependency — will be unblocked automatically       |
-| needs_decision  | Requires human judgment before work can proceed — do not dispatch |
-| failed          | Worker failed, needs re-dispatch or replan                      |
+| Status         | Meaning                                                           |
+| -------------- | ----------------------------------------------------------------- |
+| ready          | Decomposed, ready to dispatch                                     |
+| dispatched     | Sent to worker, waiting for PR                                    |
+| pr_open        | PR filed, under review                                            |
+| pr_approved    | Approved, ready to merge                                          |
+| done           | Merged and verified                                               |
+| blocked        | Waiting on a dependency — will be unblocked automatically         |
+| needs_decision | Requires human judgment before work can proceed — do not dispatch |
+| failed         | Worker failed, needs re-dispatch or replan                        |
 
 `needs_decision` maps to PKB task status `needs_review`. Agents cannot claim
 tasks in these statuses, so setting them is an enforceable gate — not an
@@ -159,13 +159,13 @@ No active polling loops. Check once per invocation.
 
 ### REACT
 
-| Problem                           | Response                                         |
-| --------------------------------- | ------------------------------------------------ |
-| Worker failed (no PR, task reset) | Re-dispatch, possibly different worker           |
-| PR has merge conflicts            | Close PR, re-dispatch on fresh base              |
-| PR got CHANGES_REQUESTED          | Read review comments, decide: fix or re-dispatch |
-| Task bigger than expected         | Decompose further, add work items                |
-| Dependency discovered             | Add depends_on, mark dependent as blocked        |
+| Problem                           | Response                                           |
+| --------------------------------- | -------------------------------------------------- |
+| Worker failed (no PR, task reset) | Re-dispatch, possibly different worker             |
+| PR has merge conflicts            | Close PR, re-dispatch on fresh base                |
+| PR got CHANGES_REQUESTED          | Read review comments, decide: fix or re-dispatch   |
+| Task bigger than expected         | Decompose further, add work items                  |
+| Dependency discovered             | Add depends_on, mark dependent as blocked          |
 | Academic integrity concern        | Set task status to `needs_review`, do not dispatch |
 
 ### INTEGRATE

--- a/specs/pr-pipeline.md
+++ b/specs/pr-pipeline.md
@@ -170,7 +170,7 @@ A PR qualifies for dispatch if ALL of the following are true:
 
 1. **Age gate:** Last commit was >= 15 minutes ago. This preserves a bazaar window for external reviews (Gemini, Copilot) to arrive before the Merge-Prep Agent triages them.
 2. **No in-progress run:** `gh run list --workflow=agent-merge-prep.yml --json status` shows no `in_progress` or `queued` run. Replaces the `merge-prep-running` label.
-3. **Not already completed or permanently halted:** The latest commit does not have a `merge-prep-status` commit status with `state: success` or `state: failure`. The Merge-Prep Agent sets `success` at the end of every successful run; it sets `failure` after 3 consecutive failures. A new commit from any actor clears this automatically — the new SHA has no status yet, so the agent will re-run.
+3. **Not already completed or permanently halted:** The latest commit does not have a `merge-prep-status` commit status with `state: success` or `state: failure`. The Merge-Prep Agent sets `success` at the end of every successful run; it sets `failure` after 3 consecutive failures. A new commit from any actor clears this automatically — the new SHA has no status yet, so the agent will re-run. **Exception — late reviews:** If `merge-prep-status` is `success` but `CHANGES_REQUESTED` reviews arrived _after_ the status was set, the PR re-qualifies. This handles the race where merge-prep's own commits trigger the Axiom Review, which finishes after merge-prep has already declared success.
 4. **Not a merge-prep commit:** The HEAD commit message does not contain a `Merge-Prep-By:` trailer. This is a race-condition guard: the `workflow_run` trigger can fire before the agent workflow sets `merge-prep-status: success` on a freshly pushed commit. The trailer check prevents wasteful re-dispatch.
 
 The dispatcher does not check whether checks are passing. The Merge-Prep Agent runs regardless — it will fix what it can and post an honest outcome.
@@ -378,7 +378,7 @@ environment:
 - [ ] No comment-text scanning in merge-prep-cron.yml (halt detection uses commit status API)
 - [ ] In-progress detection uses `gh run list` — no duplicate merge-prep runs
 - [ ] On every successful merge-prep run: `gh pr review --approve` posted, `merge-prep-status: success` commit status set on latest commit, `summary-and-merge.yml` triggered
-- [ ] Cron qualification skips PRs where latest commit has `merge-prep-status: success` (already processed) or `failure` (halted)
+- [ ] Cron qualification skips PRs where latest commit has `merge-prep-status: success` (already processed) or `failure` (halted), unless `CHANGES_REQUESTED` reviews arrived after the `success` status was set (late-review re-qualification)
 - [ ] After 3 consecutive merge-prep failures: merge-prep approval dismissed, `merge-prep-status: failure` commit status set, notification comment posted, cron skips the PR
 - [ ] Runaway loop ceiling: merge-prep halts (same as above) when `Merge-Prep-By:` commit count in branch ≥ 5
 - [ ] Manual retry via workflow_dispatch resets halt state (re-runs full success sequence if successful)


### PR DESCRIPTION
## Summary

- Fixes race condition where merge-prep declares `success` before the Axiom Review (triggered by merge-prep's own commits) finishes and posts `CHANGES_REQUESTED`
- The dispatcher now checks for `CHANGES_REQUESTED` reviews that arrived *after* the `merge-prep-status: success` timestamp — if found, the PR re-qualifies for another merge-prep run
- Spec updated to document the late-review re-qualification exception

**Root cause:** Merge-prep pushes commits during its run (merge from main, code fixes). Those commits trigger the PR Review Pipeline concurrently. Merge-prep finishes first, sets `merge-prep-status: success`. The Axiom Review finishes minutes later with `CHANGES_REQUESTED`. The dispatcher sees `success` and skips. Both #431 and #434 were stuck overnight due to this.

## Test plan

- [x] All 946 tests pass (`uv run pytest tests/`)
- [x] Pre-commit hooks pass (actionlint, dprint, markdownlint)
- [ ] Deploy and verify dispatcher re-qualifies #431 and #434 on next cron tick
- [ ] Monitor subsequent merge-prep runs to confirm they address the Axiom Review feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)