### PR TITLE
feat(build): add Cowork plugin build target

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,6 +16,16 @@
       },
       "source": "./dist/aops-claude",
       "category": "productivity"
+    },
+    {
+      "name": "aops-cowork",
+      "description": "academicOps for Cowork - stripped-down plugin with skills, agents, and tools (no hooks/scripts)",
+      "version": "0.3.16-dev.73",
+      "author": {
+        "name": "Nicolas Suzor"
+      },
+      "source": "./dist/aops-cowork",
+      "category": "productivity"
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -338,8 +338,10 @@ aops-core/.mcp.json
 
 # Distribution artifacts - built by CI
 # Claude plugin dist is tracked (served directly from this repo)
+# Cowork plugin dist is also tracked (stripped-down build for Cowork desktop)
 dist/*
 !dist/aops-claude/
+!dist/aops-cowork/
 
 streamlit_log.txt
 data/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # AcademicOps Makefile
 # Unified build and installation entry point
 
-.PHONY: help dev build-dev install-dev uninstall-dev install-remote install-claude install-gemini install-cli install-crontab install-hooks nextver release prerelease clean build build-docker shell
+.PHONY: help dev build-dev install-dev uninstall-dev install-remote install-claude install-gemini install-cowork install-cli install-crontab install-hooks nextver release prerelease clean build build-docker shell
 
 # --- Configuration ---
 
@@ -16,6 +16,7 @@ GEMINI_REMOTE_URL := https://github.com/nicsuzor/academicOps.git
 # Extension names
 GEMINI_EXT_NAME := aops-core
 CLAUDE_PLUGIN_NAME := aops-core@academicOps
+COWORK_PLUGIN_NAME := aops-cowork@academicOps
 
 # Platform detection for binaries
 UNAME_S := $(shell uname -s)
@@ -46,6 +47,7 @@ help:
 	@echo "User Installation (Install from remote releases):"
 	@echo "  make install        - Install all components from GitHub releases"
 	@echo "  make install-claude - Install Claude plugin from dist repo"
+	@echo "  make install-cowork - Install Cowork plugin from dist repo"
 	@echo "  make install-gemini - Install Gemini extension from main repo"
 	@echo "  make install-crontab - Setup background sync"
 	@echo ""
@@ -141,6 +143,14 @@ install-claude:
 	command claude plugin marketplace update academicOps && \
 	command claude plugin install $(CLAUDE_PLUGIN_NAME) && \
 	echo "✓ Claude Code plugin installed"
+
+install-cowork:
+	@echo "Installing aops plugin for Claude Cowork..."
+	@echo "  Source: $(DIST_DIR)/aops-cowork (local build)"
+	-command claude plugin uninstall $(COWORK_PLUGIN_NAME)
+	@command claude plugin marketplace add $(AOPS_ROOT) && \
+	command claude plugin install $(COWORK_PLUGIN_NAME) && \
+	echo "✓ Cowork plugin installed"
 
 install-gemini:
 	@echo "Installing aops extension for Gemini CLI..."

--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ help:
 	@echo "  make dev            - Full local dev setup (sync, build, install-dev)"
 	@echo "  make build-dev      - Build extension locally (dist/)"
 	@echo "  make install-dev    - Install current dist/ into Claude and Gemini"
+	@echo "  make install-cowork - Install Cowork plugin from local dist/aops-cowork build"
 	@echo "  make uninstall-dev  - Restore release marketplace after local testing"
 	@echo "  make install-hooks  - Install pre-commit hooks"
 	@echo ""
 	@echo "User Installation (Install from remote releases):"
 	@echo "  make install        - Install all components from GitHub releases"
 	@echo "  make install-claude - Install Claude plugin from dist repo"
-	@echo "  make install-cowork - Install Cowork plugin from dist repo"
 	@echo "  make install-gemini - Install Gemini extension from main repo"
 	@echo "  make install-crontab - Setup background sync"
 	@echo ""
@@ -107,6 +107,15 @@ cache = pathlib.Path.home() / '.claude/plugins/cache/academicOps/aops-core'; \
 	@echo "  ⚠️  Marketplace 'academicOps' now points to $(AOPS_ROOT)"
 	@echo "  Run 'make uninstall-dev' to restore the release marketplace."
 
+# Install Cowork plugin from local dist build
+install-cowork:
+	@echo "Installing aops plugin for Claude Cowork..."
+	@echo "  Source: $(DIST_DIR)/aops-cowork (local build)"
+	-command claude plugin uninstall $(COWORK_PLUGIN_NAME)
+	@command claude plugin marketplace add $(AOPS_ROOT) && \
+	command claude plugin install $(COWORK_PLUGIN_NAME) && \
+	echo "✓ Cowork plugin installed"
+
 # Restore the release marketplace after local dev testing
 uninstall-dev:
 	@echo "Restoring release marketplace ($(DIST_REPO))..."
@@ -143,14 +152,6 @@ install-claude:
 	command claude plugin marketplace update academicOps && \
 	command claude plugin install $(CLAUDE_PLUGIN_NAME) && \
 	echo "✓ Claude Code plugin installed"
-
-install-cowork:
-	@echo "Installing aops plugin for Claude Cowork..."
-	@echo "  Source: $(DIST_DIR)/aops-cowork (local build)"
-	-command claude plugin uninstall $(COWORK_PLUGIN_NAME)
-	@command claude plugin marketplace add $(AOPS_ROOT) && \
-	command claude plugin install $(COWORK_PLUGIN_NAME) && \
-	echo "✓ Cowork plugin installed"
 
 install-gemini:
 	@echo "Installing aops extension for Gemini CLI..."

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -95,7 +95,7 @@ Hooks and configuration that make every Claude Code session framework-aware:
 - Autocommit keeps state synced
 - Session transcripts captured for reflection
 - Cross-device sync via git
-- **Channels** as the central interface — Claude Code Channels (Discord, Slack) provide a unified way to interact with Claude Code clients from any device. The framework targets Claude Code as the sole runtime; Cowork is not supported (not configurable in the same way as Claude Code).
+- **Channels** as the central interface — Claude Code Channels (Discord, Slack) provide a unified way to interact with Claude Code clients from any device. The framework targets Claude Code as the primary runtime; Cowork receives a stripped-down build with skills, commands, and agents (no hooks or enforcement).
 
 ## What We've Learned
 
@@ -157,8 +157,8 @@ The PKB server does deterministic computation (search, CRUD, graph traversal). A
 
 ### Platform Focus
 
-- **Claude Code** is the sole supported runtime. All hooks, skills, and MCP servers target Claude Code.
-- **Claude Cowork is not supported.** Cowork runs in a VM with read-only plugin cache, no skill/hook execution, and no equivalent configurability. We do not invest in Cowork compatibility.
+- **Claude Code** is the primary supported runtime. All hooks, skills, and MCP servers target Claude Code.
+- **Claude Cowork** receives a stripped-down build (`dist/aops-cowork/`) containing skills, commands, agents, and MCP config. Hooks and Python-based enforcement do not run in Cowork's read-only VM environment.
 - **Channels** (Discord, Slack) provide the central interface for interacting with Claude Code clients remotely.
 
 ### Must Not Require

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run python
 """
 Build script for AcademicOps extensions.
-Generates dist/aops-gemini, dist/aops-claude, dist/aops-tools-gemini, dist/aops-tools-claude, and dist/antigravity.
+Generates dist/aops-gemini, dist/aops-claude, dist/aops-cowork, dist/aops-tools-gemini, dist/aops-tools-claude, and dist/antigravity.
 """
 
 import argparse
@@ -985,6 +985,125 @@ def build_aops_tools(
     print(f"✓ Built {plugin_name} ({platform})")
 
 
+def build_aops_cowork(
+    aops_root: Path,
+    dist_root: Path,
+    aca_data_path: str,
+    version: str = "0.1.0",
+):
+    """Build the aops-cowork plugin for Claude Cowork.
+
+    Cowork runs in a VM with a read-only plugin cache and cannot execute hooks
+    or Python scripts. This build produces a stripped-down Claude-format plugin
+    containing only the components Cowork can use:
+    - skills/ (markdown procedural knowledge)
+    - commands/ (slash command definitions)
+    - agents/ (agent definitions)
+    - .mcp.json (MCP server config)
+    - .claude-plugin/plugin.json (manifest)
+    - Documentation markdown files
+    """
+    print(f"Building aops-cowork (v{version})...")
+    src_dir = aops_root / "aops-core"
+    dist_dir = dist_root / "aops-cowork"
+
+    if dist_dir.exists():
+        shutil.rmtree(dist_dir)
+    dist_dir.mkdir(parents=True)
+
+    # Write version info
+    commit_sha = get_git_commit_sha(aops_root)
+    if commit_sha:
+        write_plugin_version(src_dir, commit_sha)
+
+    # 1. Copy only Cowork-compatible content (no hooks, lib, scripts, config)
+    COWORK_INCLUDE = {
+        "skills",
+        "commands",
+        "agents",
+    }
+    # Top-level markdown files to include
+    COWORK_MD_INCLUDE = {
+        "SKILLS.md",
+        "AXIOMS.md",
+        "HEURISTICS.md",
+        "RULES.md",
+        "INDEX.md",
+        "TAXONOMY.md",
+        "CONSTRAINTS.md",
+        "TOOLS.md",
+        "enforcement-map.md",
+        "agent-env-map.conf",
+    }
+
+    for src_item in src_dir.iterdir():
+        if src_item.name.startswith(".") or src_item.name == "__pycache__":
+            continue
+
+        if src_item.name in COWORK_INCLUDE:
+            if src_item.name == "agents" and src_item.is_dir():
+                # Transform agent frontmatter for Claude format (same as claude build)
+                dst = dist_dir / src_item.name
+                dst.mkdir(parents=True, exist_ok=True)
+                for agent_file in src_item.glob("*.md"):
+                    content = agent_file.read_text()
+                    content = transform_agent_for_platform(content, "claude", agent_file.name)
+                    (dst / agent_file.name).write_text(content)
+                print(f"  ✓ Copied agents -> {dst}")
+            else:
+                safe_copy(src_item, dist_dir / src_item.name)
+        elif src_item.is_file() and src_item.name in COWORK_MD_INCLUDE:
+            safe_copy(src_item, dist_dir / src_item.name)
+
+    # 2. Plugin manifest — same format as Claude Code but with hooks stripped
+    src_plugin_json = src_dir / ".claude-plugin" / "plugin.json"
+    dist_plugin_dir = dist_dir / ".claude-plugin"
+    dist_plugin_dir.mkdir(parents=True, exist_ok=True)
+    if src_plugin_json.exists():
+        manifest = json.loads(src_plugin_json.read_text())
+        manifest["version"] = version
+        manifest["name"] = "aops-cowork"
+        manifest["description"] = (
+            "academicOps for Cowork - skills, agents, and tools for research workflow automation"
+        )
+        # Cowork cannot execute hooks, so we don't reference them
+        with open(dist_plugin_dir / "plugin.json", "w") as f:
+            json.dump(manifest, f, indent=2)
+            f.write("\n")
+        print(f"  ✓ Generated plugin.json (v{version})")
+
+    # 3. MCP config — Cowork uses the same format as Claude Code
+    template_path = src_dir / "mcp.json.template"
+    if template_path.exists():
+        mcp_template = json.loads(template_path.read_text())
+        claude_mcp_config = mcp_template.get("claude", mcp_template)
+        with open(dist_dir / ".mcp.json", "w") as f:
+            json.dump(claude_mcp_config, f, indent=2)
+            f.write("\n")
+        print("  ✓ Generated .mcp.json")
+
+    # 4. Also include aops-tools skills if available
+    tools_src = aops_root / "aops-tools" / "skills"
+    if tools_src.exists():
+        tools_skills_dst = dist_dir / "skills"
+        # Merge tool skills into the main skills directory
+        for skill_dir in tools_src.iterdir():
+            dst = tools_skills_dst / skill_dir.name
+            if not dst.exists():
+                safe_copy(skill_dir, dst)
+        tools_index = aops_root / "aops-tools" / "SKILLS.md"
+        if tools_index.exists():
+            # Append tools skills index to main SKILLS.md
+            main_skills_md = dist_dir / "SKILLS.md"
+            if main_skills_md.exists():
+                with open(main_skills_md, "a") as f:
+                    f.write("\n\n## Domain Tools\n\n")
+                    f.write(tools_index.read_text())
+        print("  ✓ Merged aops-tools skills")
+
+    print("✓ Built aops-cowork")
+
+
 def build_antigravity(aops_root: Path, dist_root: Path, all_mcps: dict):
     """Build the antigravity distribution."""
     print("Building antigravity...")
@@ -1122,6 +1241,9 @@ def main():
     build_aops_tools(aops_root, dist_root, "gemini", version)
     build_aops_tools(aops_root, dist_root, "claude", version)
 
+    # Build Cowork plugin (stripped-down Claude-format for Cowork desktop)
+    build_aops_cowork(aops_root, dist_root, aca_data_path, version)
+
     # Install PKB binary if provided
     pkb_binary = Path(args.pkb_binary) if args.pkb_binary else None
     if pkb_binary:
@@ -1218,7 +1340,16 @@ def package_artifacts(
     print(f"  ✓ Packaged {claude_archive.name}")
     safe_symlink(claude_archive, dist_root / "aops-claude-latest.tar.gz")
 
-    # 3. aops-antigravity-v{version}.tar.gz
+    # 3. aops-cowork-v{version}.tar.gz
+    cowork_dir = dist_root / "aops-cowork"
+    if cowork_dir.exists():
+        cowork_archive = dist_root / f"aops-cowork-v{version}.tar.gz"
+        with tarfile.open(cowork_archive, "w:gz") as tar:
+            tar.add(cowork_dir, arcname="aops-cowork", filter=_source_filter)
+        print(f"  ✓ Packaged {cowork_archive.name}")
+        safe_symlink(cowork_archive, dist_root / "aops-cowork-latest.tar.gz")
+
+    # 4. aops-antigravity-v{version}.tar.gz
     antigravity_archive = dist_root / f"aops-antigravity-v{version}.tar.gz"
     with tarfile.open(antigravity_archive, "w:gz") as tar:
         tar.add(dist_root / "aops-antigravity", arcname=".", filter=_source_filter)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1048,6 +1048,7 @@ def build_aops_cowork(
                 for agent_file in src_item.glob("*.md"):
                     content = agent_file.read_text()
                     content = transform_agent_for_platform(content, "claude", agent_file.name)
+                    content = translate_tool_calls(content, "claude")
                     (dst / agent_file.name).write_text(content)
                 print(f"  ✓ Copied agents -> {dst}")
             else:

--- a/tests/test_build_cowork_includes.py
+++ b/tests/test_build_cowork_includes.py
@@ -1,0 +1,85 @@
+"""Test that build.py's Cowork inclusion sets reference real paths in aops-core/.
+
+Prevents silent regression where COWORK_INCLUDE or COWORK_MD_INCLUDE reference
+directories or files that have been renamed, removed, or moved. Without this test,
+the Cowork build would silently produce an incomplete plugin with no error or warning.
+
+Pattern mirrors tests/test_build_file_completeness.py which covers the analogous
+excludelist for the Claude/Gemini builds.
+"""
+
+import ast
+from pathlib import Path
+
+AOPS_CORE_DIR = Path(__file__).resolve().parent.parent / "aops-core"
+BUILD_PY = Path(__file__).resolve().parent.parent / "scripts" / "build.py"
+
+
+def _get_cowork_sets() -> tuple[set[str], set[str]]:
+    """Parse build.py to extract COWORK_INCLUDE and COWORK_MD_INCLUDE via AST."""
+    content = BUILD_PY.read_text()
+    tree = ast.parse(content)
+
+    cowork_include: set[str] | None = None
+    cowork_md_include: set[str] | None = None
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "build_aops_cowork":
+            for sub_node in ast.walk(node):
+                if isinstance(sub_node, ast.Assign):
+                    for target in sub_node.targets:
+                        if not isinstance(target, ast.Name):
+                            continue
+                        if target.id == "COWORK_INCLUDE" and isinstance(sub_node.value, ast.Set):
+                            cowork_include = {
+                                elt.value
+                                for elt in sub_node.value.elts
+                                if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                            }
+                        elif target.id == "COWORK_MD_INCLUDE" and isinstance(
+                            sub_node.value, ast.Set
+                        ):
+                            cowork_md_include = {
+                                elt.value
+                                for elt in sub_node.value.elts
+                                if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                            }
+
+    if cowork_include is None:
+        raise RuntimeError(
+            "Could not find 'COWORK_INCLUDE' set in 'build_aops_cowork' function in build.py"
+        )
+    if cowork_md_include is None:
+        raise RuntimeError(
+            "Could not find 'COWORK_MD_INCLUDE' set in 'build_aops_cowork' function in build.py"
+        )
+
+    return cowork_include, cowork_md_include
+
+
+def test_cowork_include_dirs_exist() -> None:
+    """Every entry in COWORK_INCLUDE must resolve to a real directory under aops-core/."""
+    cowork_include, _ = _get_cowork_sets()
+
+    missing = {
+        name for name in cowork_include if not (AOPS_CORE_DIR / name).is_dir()
+    }
+
+    assert not missing, (
+        f"COWORK_INCLUDE references directories that don't exist in aops-core/: {sorted(missing)}. "
+        "Update COWORK_INCLUDE in build_aops_cowork() to match actual directory names."
+    )
+
+
+def test_cowork_md_include_files_exist() -> None:
+    """Every entry in COWORK_MD_INCLUDE must resolve to a real file under aops-core/."""
+    _, cowork_md_include = _get_cowork_sets()
+
+    missing = {
+        name for name in cowork_md_include if not (AOPS_CORE_DIR / name).is_file()
+    }
+
+    assert not missing, (
+        f"COWORK_MD_INCLUDE references files that don't exist in aops-core/: {sorted(missing)}. "
+        "Update COWORK_MD_INCLUDE in build_aops_cowork() to match actual file names."
+    )

--- a/tests/test_build_cowork_includes.py
+++ b/tests/test_build_cowork_includes.py
@@ -61,9 +61,7 @@ def test_cowork_include_dirs_exist() -> None:
     """Every entry in COWORK_INCLUDE must resolve to a real directory under aops-core/."""
     cowork_include, _ = _get_cowork_sets()
 
-    missing = {
-        name for name in cowork_include if not (AOPS_CORE_DIR / name).is_dir()
-    }
+    missing = {name for name in cowork_include if not (AOPS_CORE_DIR / name).is_dir()}
 
     assert not missing, (
         f"COWORK_INCLUDE references directories that don't exist in aops-core/: {sorted(missing)}. "
@@ -75,9 +73,7 @@ def test_cowork_md_include_files_exist() -> None:
     """Every entry in COWORK_MD_INCLUDE must resolve to a real file under aops-core/."""
     _, cowork_md_include = _get_cowork_sets()
 
-    missing = {
-        name for name in cowork_md_include if not (AOPS_CORE_DIR / name).is_file()
-    }
+    missing = {name for name in cowork_md_include if not (AOPS_CORE_DIR / name).is_file()}
 
     assert not missing, (
         f"COWORK_MD_INCLUDE references files that don't exist in aops-core/: {sorted(missing)}. "


### PR DESCRIPTION
Add build_aops_cowork() to produce a stripped-down Claude-format plugin
for Cowork desktop. Cowork runs in a read-only VM without hook or script
execution, so this build includes only skills, commands, agents, MCP
config, and documentation markdown. Domain tools skills from aops-tools
are merged into the single output at dist/aops-cowork/.

- New build function in scripts/build.py
- Cowork archive packaging in package_artifacts()
- Makefile install-cowork target
- .gitignore updated to track dist/aops-cowork/
- VISION.md updated to reflect Cowork support

https://claude.ai/code/session_01AiQFVtawCHmFN8sHF1VKcn