### PR TITLE
docs(taxonomy): rewrite with information-theoretic model

### DIFF
--- a/aops-core/TAXONOMY.md
+++ b/aops-core/TAXONOMY.md
@@ -12,19 +12,166 @@ tags: [framework, taxonomy, canonical, reference]
 
 This document is the **single authoritative source** for all framework concepts. Every other document in the framework MUST use these terms consistently. When in doubt, this document wins.
 
-## The Hierarchy
+---
 
-```
-GOAL (multi-month/year desired outcome)
-  └─ PROJECT (coherent body of work toward a goal)
-      └─ EPIC (PR-sized unit of verifiable work)
-          └─ TASK (discrete deliverable within an epic)
-              └─ ACTION (single-session step within a task)
-```
+## Core Principle: All Nodes Are One Object
 
-Every node has exactly one parent. Goals are roots. Tasks never float free — they always belong to an epic.
+Every node in the PKB is the same fundamental data structure. There is no structural difference between a "project" and a "task" at the data level — both are graph nodes with the same fields and computed properties.
+
+**Labels** (`type: project`, `type: epic`, etc.) are **views on computed property ranges**, not structural types assigned to fixed tree depths. A node is called an "epic" because its scope and uncertainty fall in the epic range — not because it happens to live at depth 3.
+
+This matters because work decomposition is self-similar: decomposing a project looks exactly like decomposing a task. The stopping condition is residual uncertainty, which is a property of the node, not a function of its depth.
+
+---
+
+## The Compression Model
+
+The task graph has intrinsic complexity — the full specification of all work, dependencies, and context. The hierarchy's job is to **compress** this into something that fits through the bottleneck of human working memory.
+
+A flat todo list is a fixed-rate code: it treats every item as having the same complexity. The hierarchy is a **variable-rate code** that allocates more structure to high-complexity work and less to simple work.
+
+Each level resolves a different kind of uncertainty:
+
+| Level   | Uncertainty resolved         | Remaining uncertainty          |
+| ------- | ---------------------------- | ------------------------------ |
+| Goal    | What success looks like      | Which bodies of work to pursue |
+| Project | Which coherent body of work  | How to decompose the work      |
+| Epic    | What to do and in what order | How to execute each step       |
+| Task    | What to execute              | Nothing — ready to act         |
+
+**Compression principle**: Each level must be self-contained. Understanding a node should not require holding its grandparent's context in working memory. If it does, the decomposition has failed — information is leaking across compression boundaries.
+
+---
+
+## Computed Properties
+
+Every node carries three computed properties that drive both label assignment and tooling:
+
+### scope
+
+**What it measures**: Subtree size — the total count of descendants.
+
+**How computed**: Recursive count of all children, grandchildren, etc., with a cycle guard to handle soft cycles.
+
+**What it tells you**: How much work lives under this node. High scope = strategic container. Low scope = leaf-level work.
+
+### uncertainty
+
+**What it measures**: Residual ambiguity — how much is still unknown about what exactly needs to be done. Range: `0.0` (fully specified) to `1.0` (vague).
+
+**How computed**: Composite signal from:
+
+- `has_children`: decomposed work reduces uncertainty
+- `has_acceptance_criteria`: explicit success criteria reduce uncertainty
+- `dep_resolution_ratio`: fraction of dependencies that are resolved
+- `body_length`: fuller description signals more specified intent
+- explicit confidence override: author can pin uncertainty directly
+
+**What it tells you**: Whether a node is ready to act on. Low uncertainty = can execute. High uncertainty = needs more thinking or decomposition.
+
+### criticality
+
+**What it measures**: Impact on goal achievement — how much this node matters relative to the rest of the graph.
+
+**How computed**: Normalized composite of:
+
+- `downstream_weight`: count of nodes that depend (transitively) on this one completing
+- `pagerank`: structural influence in the dependency graph
+- `stakeholder_exposure`: explicit priority/stakeholder signals
+
+**What it tells you**: Which nodes to work on first when time is scarce. High criticality = unblocks many downstream nodes. Low criticality = isolated or terminal work.
+
+### depth and leaf
+
+- **depth**: Distance from root (parent chain walk). Advisory — does not determine label.
+- **leaf**: Boolean. True when the node has no children AND uncertainty is low. A leaf is the unit of direct action.
+
+---
+
+## Labels as Property Ranges
+
+These ranges map conventional labels to computed property values. They are **guidelines for navigation, not enforcement gates**. Tooling uses these to present a sensible default view; the properties drive actual scheduling.
+
+| Label       | Scope | Uncertainty | Typical behaviour                                     |
+| ----------- | ----- | ----------- | ----------------------------------------------------- |
+| **Goal**    | > 50  | > 0.7       | Target distribution — defines what success looks like |
+| **Project** | > 15  | varies      | Partition of goal space — a coherent body of work     |
+| **Epic**    | 3–20  | < 0.5       | Sufficient statistic for execution — what to do       |
+| **Task**    | 0–3   | < 0.3       | Near-zero entropy — ready to act                      |
+
+A node with scope 25 but clear acceptance criteria and resolved dependencies might be a well-decomposed epic, not a project. The label is a human-facing shorthand; the properties are authoritative.
+
+**Why not fixed depth?** Forcing work into exactly 4 levels causes two failure modes:
+
+- Simple work gets **over-decomposed** — phantom epics created just to satisfy the hierarchy
+- Complex work gets **under-decomposed** — months of work crammed into one "epic"
+
+Variable-rate decomposition stops when uncertainty is low enough to act — regardless of depth.
+
+---
+
+## Actionable Types
+
+The four actionable node types in the PKB:
+
+| Type        | Description                                                                                                                          |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **project** | A discrete thing we work on — a noun with defined scope and boundaries                                                               |
+| **epic**    | A bundle of related work that together achieves an aim — a verb                                                                      |
+| **task**    | A discrete deliverable, completable in a single focused session                                                                      |
+| **learn**   | Observational tracking — a spike, discovery, or noted finding. Not directly actionable; resolves by decomposing into follow-up tasks |
+
+The `classification` field carries additional semantic subtypes (bug, feature, spike, chore, etc.) without multiplying top-level types.
+
+---
+
+## Edge Semantics and Cycle Policy
+
+The graph is **directed but not required to be acyclic**. Cycles are a feature for some edge types and a pathology for others.
+
+| Edge type       | Semantics                                      | Cycles       | Example                                                     |
+| --------------- | ---------------------------------------------- | ------------ | ----------------------------------------------------------- |
+| `Parent`        | Containment: B is part of A                    | Nonsensical  | Self-containment is undefined — never valid                 |
+| `DependsOn`     | Hard blocker: B cannot start until A completes | Pathological | A blocks B blocks A — decomposition failure, must fix       |
+| `SoftDependsOn` | Enabling: A makes B easier or better           | Healthy      | Writing clarifies methodology, methodology improves writing |
+| `Link`          | Reference: A mentions B                        | Irrelevant   | Cross-references carry no ordering — always fine            |
+| `Supersedes`    | Replacement: A replaces B                      | Pathological | Mutual replacement is undefined — never valid               |
+
+### Cycle detection policy
+
+**Hard cycles** (DependsOn + Parent edges): Detected via Tarjan's SCC. Any strongly connected component with more than one node is a decomposition failure requiring human review. These are surfaced as errors.
+
+**Soft cycles** (SoftDependsOn edges): Counted and reported but not flagged as errors. Mutual reinforcement is a normal property of academic work — writing clarifies thinking, thinking improves writing.
+
+### Dependencies as mutual information
+
+When two tasks have high mutual information — knowing A's state tells you about B's state — they belong in the same container (epic). When tasks are independent, they can live in different containers.
+
+The tree hierarchy is a **spanning tree** of the underlying dependency graph. It captures containment but drops cross-cutting dependency edges. Tooling must surface full dependency chains ("blocked by X, which is blocked by Y"), not just immediate blockers.
+
+---
+
+## Status Values and Transitions
+
+| Status        | Meaning                                                              |
+| ------------- | -------------------------------------------------------------------- |
+| `inbox`       | Captured but not yet triaged — unknown priority, unknown readiness   |
+| `ready`       | All hard dependencies resolved, uncertainty low enough to act        |
+| `in_progress` | Claimed by an agent or human — actively being worked                 |
+| `merge_ready` | Work complete and committed, waiting for review/merge                |
+| `done`        | Complete — no further action required                                |
+| `blocked`     | Waiting on an external dependency that cannot be resolved internally |
+| `cancelled`   | Will not be done — decision made to drop                             |
+
+**Ready means ready**: A task should only appear as `ready` when uncertainty is low AND all upstream `DependsOn` edges are resolved — not merely when it has no children.
+
+**Propagation**: Completion of a node should trigger readiness re-evaluation of all nodes that depend on it. The system surfaces dependency chains so that cascading unblocks are visible.
+
+---
 
 ## The Orchestration Layer
+
+Separate from the task hierarchy, the orchestration layer describes how work is executed:
 
 ```
 WORKFLOW (composable step arrangement for achieving an epic)
@@ -35,180 +182,87 @@ WORKFLOW (composable step arrangement for achieving an epic)
 
 Workflows define WHAT to do and in WHAT order. Skills define HOW to do a single step. Skills are fungible — you can swap one for another that does the same thing. Procedures are skill-internal details that only make sense within that skill.
 
----
-
-## Concept Definitions
-
-### Goal
-
-A desired future state, typically multi-month or multi-year in scope. Goals are directional — they describe where you want to be, not exactly how to get there. A goal may be vague and is expected to evolve.
-
-**Examples**: "Transform academicOps into autonomous academic research engine", "World-class academic profile"
-
-**Children**: Projects
-
-**Anti-pattern**: A goal with tasks directly underneath. If you can do it in a session, it's not a goal.
-
-### Project
-
-A **noun** — a discrete, specific thing we work on. A project has a defined scope, clear boundaries, and produces tangible outputs. Projects are ongoing — they can run for weeks or months. You should be able to point to what the thing IS.
-
-**Examples**: "AcademicOps", "OSB Political Speech Benchmarking", "TJA", "Network Planning"
-
-**Children**: Epics (and sub-projects, rarely)
-
-**Anti-pattern**: A project with direct task children. Tasks belong to epics, not projects.
-
-**Anti-pattern**: A "project" that is really a category — a grab-bag of unrelated work. "Explorations" or "Misc" are categories, not projects. If children serve different aims, they belong to different projects.
-
-### Epic
-
-A **verb** — a bundle of related work that together achieves an aim within a project. An epic is PR-sized: a coherent set of changes that can be reviewed, tested, and merged together. An epic is complete when all of its workflow steps pass — planning, execution, and verification.
-
-An epic includes:
-
-1. **Planning tasks**: Methodology, acceptance criteria, approach design
-2. **Execution tasks**: The actual work
-3. **Verification tasks**: Testing, QA, cross-referencing, review
-
-In the Bazaar model, different agents may handle different tasks within an epic. The quality guarantee comes from the workflow structure — if every required step is verifiably complete, the epic is good. A failure at any step fails the entire epic until fixed or abandoned.
-
-**Typical scope**: 5–20 hours across multiple sessions. Multiple distinct deliverables. Results in one PR or one reviewable unit.
-
-**Children**: Tasks, bugs, features
-
-**Anti-pattern**: An epic that is really a project (months of work, dozens of tasks). If it needs more than ~12 child tasks, decompose into sub-epics or reclassify as a project.
-
-**Anti-pattern**: An epic with no verification tasks. Every epic must include at least one QA/review step to be considered verifiable.
-
-### Task
-
-A discrete deliverable within an epic. A task can be completed in a single focused session (1–4 hours) and produces a specific, identifiable output.
-
-**Examples**: "Write acceptance criteria for dashboard", "Implement sort function", "Run regression tests"
-
-**Parent**: Always an epic
-
-**Children**: Actions (optional, for multi-step tasks)
-
-**Anti-pattern**: An orphan task with no epic parent. Find or create the epic first.
-
-**Anti-pattern**: A task that takes multiple sessions. That's an epic, not a task.
-
-### Action
-
-A single work step within a task, completable in under 30 minutes. Actions are optional — not every task needs to be decomposed into actions.
-
-**Examples**: "Add import statement", "Run test suite", "Update config file"
-
-### Bug, Feature
-
-Specialised task types that follow the same rules as tasks but carry semantic meaning about what kind of work they represent.
-
-### Learn
-
-Observational tracking — not actionable work, but a record of something discovered or noted. Learns can be attached at any level.
-
----
-
-## Orchestration Concepts
-
 ### Workflow
 
-A **brief, composable arrangement of steps** that describes how to achieve an epic. A workflow answers "WHAT do we do and in WHAT order?" — not "HOW do we do each step."
+A **composable arrangement of steps** that describes how to achieve an epic. Answers "WHAT do we do and in WHAT order?" — not "HOW do we do each step."
 
-Workflows are the Bazaar's quality guarantee. By defining required steps (including verification), workflows ensure that work is good enough regardless of which agent performs it. You don't need to micromanage agents if the workflow structure mandates planning before execution and verification after.
+Workflows are the Bazaar's quality guarantee. By defining required steps (including verification), workflows ensure that work is good enough regardless of which agent performs it.
 
-**Structure**: A workflow is a sequence of steps, each of which may invoke a base workflow pattern and require a specific skill. Workflows compose base patterns (task-tracking, tdd, verification, commit, handover, etc.) into coherent processes.
+**Anti-pattern**: A workflow that contains detailed HOW-TO instructions. That's a skill.
 
-**Examples**: `feature-dev` (plan → test → implement → verify → commit), `decompose` (understand → identify stages → draft tasks → verify coverage)
-
-**Anti-pattern**: A workflow that contains detailed HOW-TO instructions. That's a skill, not a workflow.
-
-**Anti-pattern**: A workflow embedded inside a skill file. Workflows are orchestration; skills are execution. A skill never contains a workflow (see Principle #0 in workflow-system-spec).
+**Anti-pattern**: A workflow embedded inside a skill file. A skill never contains a workflow.
 
 ### Step
 
-One unit within a workflow. A step has a clear purpose, an expected output, and may specify which skill an agent needs to execute it.
-
-**Examples**: "Write acceptance criteria" (step in a feature-dev workflow, uses QA skill), "Run regression tests" (step in verification workflow, uses testing skill)
+One unit within a workflow. Has a clear purpose, an expected output, and may specify which skill is needed to execute it.
 
 ### Skill
 
-Instructions to an individual agent about **HOW to achieve a workflow step**. A skill is domain expertise packaged as a document: what tools to use, what quality criteria to meet, what patterns to follow, what anti-patterns to avoid.
+Instructions to an individual agent about **HOW to achieve a workflow step**. Domain expertise packaged as a document: what tools to use, what quality criteria to meet, what patterns to follow.
 
-**Skills are fungible.** You could use the Outlook email skill or the Gmail email skill to achieve the workflow step "check my email" — it doesn't matter which. This is what enables the Bazaar model: a workflow defines the required steps, and any agent with a skill that satisfies the step can fill the slot. Users can swap skills in and out without changing the workflow.
-
-**Structure**: A skill document contains the domain expertise needed for one type of work. It may include **procedures** — detailed internal instructions for HOW this particular skill accomplishes its tasks. But it should NOT contain workflows (general orchestration that could be achieved by a different skill).
-
-**Examples**: `python-dev` (how to write production-quality Python), `qa` (how to verify work meets criteria), `pdf` (how to create formatted PDFs)
-
-**Anti-pattern**: A skill with an embedded workflow router ("If you need to do X, use workflow A; if Y, use workflow B"). That routing belongs in WORKFLOWS.md, not in a skill file.
+**Skills are fungible.** A workflow step like "check my email" can be satisfied by any email skill (Outlook, Gmail, etc.). This is what enables the Bazaar model.
 
 ### Procedure
 
-A **skill-internal instruction** that describes HOW a specific skill accomplishes a task. Procedures are tightly coupled to their skill — they only make sense in the context of that skill's tools, conventions, and domain knowledge. Unlike workflows, procedures are NOT fungible: you can't swap in a different skill to follow the same procedure.
+A **skill-internal instruction** describing HOW a specific skill accomplishes a task. Tightly coupled to its skill — meaningless outside of it.
 
-**Location**: `skills/{name}/procedures/*.md` (NOT `workflows/` — that name is reserved for general orchestration).
+**Location**: `skills/{name}/procedures/*.md`
 
-**Examples**: `remember/procedures/capture.md` (how the remember skill captures knowledge), `framework/procedures/01-design-new-component.md` (how to add a new component to this specific framework)
-
-**Test**: Could a different skill achieve the same outcome by following these instructions? If yes, it's a workflow (move to global `workflows/`). If no (the instructions are meaningless outside this skill), it's a procedure.
+**Test**: Could a different skill achieve the same outcome by following these instructions? If yes → workflow. If no → procedure.
 
 ---
 
 ## Key Principles
 
-### 1. Every task belongs to an epic
+### 1. Labels emerge from properties, not position
 
-No orphan tasks. If a task exists, there must be an epic that gives it purpose and context. If you can't identify the epic, create one — even a lightweight one — before creating the task.
+A node is an "epic" because its scope and uncertainty fall in the epic range, not because it lives at depth 3. Labels are navigation aids; properties drive scheduling and tooling.
 
-### 2. Epics are PR-sized and verifiable
+### 2. Decompose until uncertainty is low enough to act
 
-An epic is not an arbitrary container. It's sized for review: small enough to understand in one sitting, large enough to be a meaningful unit of progress. It includes its own verification steps.
+The stopping condition for decomposition is residual uncertainty, not depth. Stop when a node has clear acceptance criteria, resolved dependencies, and a body specific enough to execute in one session.
 
-### 3. Workflows orchestrate; skills execute; skills are fungible
+### 3. Hard dependency cycles are decomposition failures
 
-Workflows define WHAT steps to take and in WHAT order. Skills define HOW to execute a step. A workflow may reference multiple skills. A skill NEVER contains a workflow — it may contain procedures (skill-internal HOW-TO), but not orchestration (general WHAT-TO-DO). Skills are fungible: a workflow step like "check email" can be satisfied by any email skill (Outlook, Gmail, etc.). This separation is what makes the Bazaar model work — workflows guarantee quality through structure, and any agent with the right skill can fill each slot.
+If A blocks B and B blocks A, the decomposition is wrong. Restructure — either merge them, or identify a dependency direction. Soft dependency cycles (mutual reinforcement) are healthy and expected.
 
-### 4. The hierarchy provides context
+### 4. Ready means all blockers resolved
 
-Each level of the hierarchy answers "why?" in terms of its parent. A task's purpose is explained by its epic. An epic's purpose is explained by its project. A project's purpose is explained by its goal. If you can't trace this chain, something is misplaced.
+A task is only ready when its uncertainty is low AND all DependsOn edges point to completed nodes. "Leaf" is not sufficient.
 
-### 5. Failure propagates up within an epic
+### 5. The hierarchy provides context
 
-In the Bazaar model, a failure at any workflow step (a failed test, a rejected review, an inadequate plan) fails the entire epic. This is by design — it's how we achieve quality without micromanaging agents. The epic isn't done until all required steps verifiably pass.
+Each level answers "why?" in terms of its parent. A task's purpose is explained by its epic. An epic's purpose is explained by its project. If you can't trace this chain, something is misplaced.
 
----
+### 6. Workflows orchestrate; skills execute; skills are fungible
 
-## Relationships Between Concepts
-
-```
-HIERARCHY                          ORCHESTRATION
-─────────                          ─────────────
-Goal                               Workflow
- └─ Project                         ├─ Step 1 → Skill A
-     └─ Epic ◄──── achieved by ────►├─ Step 2 → Skill B
-         ├─ Task                    ├─ Step 3 → Skill A
-         ├─ Task                    └─ Step 4 → Skill C
-         └─ Task
-```
-
-An epic is achieved by executing a workflow. The workflow's steps correspond to (but are not identical to) the epic's child tasks. The workflow defines the required sequence; the tasks are the concrete work items created to fulfill each step.
+Workflows define WHAT steps to take and in WHAT order. Skills define HOW to execute a step. A skill NEVER contains a workflow — it may contain procedures (skill-internal HOW-TO), but not orchestration. This separation is what makes the Bazaar model work.
 
 ---
 
-## Quick Reference: "Is this a...?"
+## Quick Reference
 
-| Question                                                | Answer       |
-| ------------------------------------------------------- | ------------ |
-| Multi-month desired outcome?                            | **Goal**     |
-| Coherent body of work toward a goal?                    | **Project**  |
-| PR-sized unit with planning + execution + verification? | **Epic**     |
-| Single-session deliverable within an epic?              | **Task**     |
-| Sub-30-minute step within a task?                       | **Action**   |
-| Sequence of steps describing WHAT to do?                | **Workflow** |
-| Instructions for HOW to do one step?                    | **Skill**    |
+### Is this a...?
+
+| Question                                                    | Answer       |
+| ----------------------------------------------------------- | ------------ |
+| Scope > 50, uncertainty > 0.7?                              | **Goal**     |
+| Scope > 15, coherent body of work toward a goal?            | **Project**  |
+| Scope 3–20, uncertainty < 0.5, can be reviewed as one unit? | **Epic**     |
+| Scope 0–3, uncertainty < 0.3, single-session deliverable?   | **Task**     |
+| Discovery or spike — not directly actionable?               | **Learn**    |
+| Sequence of steps describing WHAT to do?                    | **Workflow** |
+| Instructions for HOW to do one step?                        | **Skill**    |
+
+### Edge type guide
+
+| Relationship                     | Use             |
+| -------------------------------- | --------------- |
+| B is part of A (containment)     | `Parent`        |
+| B cannot start until A completes | `DependsOn`     |
+| A makes B easier/better          | `SoftDependsOn` |
+| A mentions or references B       | `Link`          |
+| A replaces B                     | `Supersedes`    |
 
 ---
 
@@ -217,3 +271,5 @@ An epic is achieved by executing a workflow. The workflow's steps correspond to 
 This document supersedes any conflicting definitions in other framework files. If another document defines these terms differently, that document should be updated to reference this one.
 
 **Referenced by**: TASK_FORMAT_GUIDE.md, WORKFLOWS.md, SKILLS.md, all SKILL.md files, workflow-system-spec.md
+
+**Supersedes**: Fixed-depth waterfall definitions (Goal→Project→Epic→Task as structural types at fixed depths). See `knowledge/framework/taxonomy-redesign-information-theoretic.md` for the design rationale.

--- a/aops-core/TAXONOMY.md
+++ b/aops-core/TAXONOMY.md
@@ -43,15 +43,15 @@ Each level resolves a different kind of uncertainty:
 
 ---
 
-## Computed Properties
+## Core Computed Properties
 
-Every node carries three computed properties that drive both label assignment and tooling:
+Every node carries three core computed properties that drive both label assignment and tooling:
 
 ### scope
 
 **What it measures**: Subtree size — the total count of descendants.
 
-**How computed**: Recursive count of all children, grandchildren, etc., with a cycle guard to handle soft cycles.
+**How computed**: Recursive count of all children, grandchildren, etc., via Parent edges (with a cycle guard for invalid Parent cycles).
 
 **What it tells you**: How much work lives under this node. High scope = strategic container. Low scope = leaf-level work.
 
@@ -61,7 +61,7 @@ Every node carries three computed properties that drive both label assignment an
 
 **How computed**: Composite signal from:
 
-- `has_children`: decomposed work reduces uncertainty
+- `has_children`: decomposed nodes have lower uncertainty than undecomposed equivalents at the same scope (high-scope nodes may still remain above task thresholds even when decomposed)
 - `has_acceptance_criteria`: explicit success criteria reduce uncertainty
 - `dep_resolution_ratio`: fraction of dependencies that are resolved
 - `body_length`: fuller description signals more specified intent
@@ -84,7 +84,7 @@ Every node carries three computed properties that drive both label assignment an
 ### depth and leaf
 
 - **depth**: Distance from root (parent chain walk). Advisory — does not determine label.
-- **leaf**: Boolean. True when the node has no children AND uncertainty is low. A leaf is the unit of direct action.
+- **leaf**: Boolean. True when the node has no children AND uncertainty is low. A structural indicator of decomposition completeness — not sufficient for execution readiness (which also requires resolved DependsOn edges).
 
 ---
 
@@ -94,10 +94,10 @@ These ranges map conventional labels to computed property values. They are **gui
 
 | Label       | Scope | Uncertainty | Typical behaviour                                     |
 | ----------- | ----- | ----------- | ----------------------------------------------------- |
-| **Goal**    | > 50  | > 0.7       | Target distribution — defines what success looks like |
-| **Project** | > 15  | varies      | Partition of goal space — a coherent body of work     |
-| **Epic**    | 3–20  | < 0.5       | Sufficient statistic for execution — what to do       |
-| **Task**    | 0–3   | < 0.3       | Near-zero entropy — ready to act                      |
+| **goal**    | > 50  | > 0.7       | Target distribution — defines what success looks like |
+| **project** | > 15  | varies      | Partition of goal space — a coherent body of work     |
+| **epic**    | 3–20  | < 0.5       | Sufficient statistic for execution — what to do       |
+| **task**    | 0–3   | < 0.3       | Near-zero entropy — ready to act                      |
 
 A node with scope 25 but clear acceptance criteria and resolved dependencies might be a well-decomposed epic, not a project. The label is a human-facing shorthand; the properties are authoritative.
 
@@ -110,12 +110,13 @@ Variable-rate decomposition stops when uncertainty is low enough to act — rega
 
 ---
 
-## Actionable Types
+## Primary Node Types
 
-The four actionable node types in the PKB:
+The five primary node types in the PKB:
 
 | Type        | Description                                                                                                                          |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **goal**    | A multi-month/year desired outcome — the root of the hierarchy                                                                       |
 | **project** | A discrete thing we work on — a noun with defined scope and boundaries                                                               |
 | **epic**    | A bundle of related work that together achieves an aim — a verb                                                                      |
 | **task**    | A discrete deliverable, completable in a single focused session                                                                      |
@@ -139,7 +140,7 @@ The graph is **directed but not required to be acyclic**. Cycles are a feature f
 
 ### Cycle detection policy
 
-**Hard cycles** (DependsOn + Parent edges): Detected via Tarjan's SCC. Any strongly connected component with more than one node is a decomposition failure requiring human review. These are surfaced as errors.
+**Hard cycles** (DependsOn + Parent edges): Detected via Tarjan's SCC. Any strongly connected component with more than one node, or any single-node SCC that has a self-edge, is a decomposition failure requiring human review. These are surfaced as errors.
 
 **Soft cycles** (SoftDependsOn edges): Counted and reported but not flagged as errors. Mutual reinforcement is a normal property of academic work — writing clarifies thinking, thinking improves writing.
 
@@ -166,6 +167,8 @@ The tree hierarchy is a **spanning tree** of the underlying dependency graph. It
 **Ready means ready**: A task should only appear as `ready` when uncertainty is low AND all upstream `DependsOn` edges are resolved — not merely when it has no children.
 
 **Propagation**: Completion of a node should trigger readiness re-evaluation of all nodes that depend on it. The system surfaces dependency chains so that cascading unblocks are visible.
+
+**Canonical authority**: This is the canonical status set. Discrepancies in other framework documents (e.g. implementation specs using additional statuses like `active`, `waiting`, or `review`) should be resolved by updating those documents to align with this list or explicitly scoping their additional statuses to their subsystem.
 
 ---
 
@@ -232,7 +235,7 @@ A task is only ready when its uncertainty is low AND all DependsOn edges point t
 
 ### 5. The hierarchy provides context
 
-Each level answers "why?" in terms of its parent. A task's purpose is explained by its epic. An epic's purpose is explained by its project. If you can't trace this chain, something is misplaced.
+Each level answers "why?" in terms of its parent. A task's purpose is explained by its epic. An epic's purpose is explained by its project. A project's purpose is explained by its goal. If you can't trace this chain, something is misplaced.
 
 ### 6. Workflows orchestrate; skills execute; skills are fungible
 
@@ -270,6 +273,6 @@ Workflows define WHAT steps to take and in WHAT order. Skills define HOW to exec
 
 This document supersedes any conflicting definitions in other framework files. If another document defines these terms differently, that document should be updated to reference this one.
 
-**Referenced by**: TASK_FORMAT_GUIDE.md, WORKFLOWS.md, SKILLS.md, all SKILL.md files, workflow-system-spec.md
+**Referenced by**: `aops-core/SKILLS.md`, all `SKILL.md` files, `specs/workflow-system-spec.md`, `aops-core/skills/planner/WORKFLOWS.md`
 
-**Supersedes**: Fixed-depth waterfall definitions (Goal→Project→Epic→Task as structural types at fixed depths). See `knowledge/framework/taxonomy-redesign-information-theoretic.md` for the design rationale.
+**Supersedes**: Fixed-depth waterfall definitions (Goal→Project→Epic→Task as structural types at fixed depths).


### PR DESCRIPTION
## Summary

- Rewrites `aops-core/TAXONOMY.md` to replace fixed-depth waterfall definitions (Goal→Project→Epic→Task as structural types at fixed depths) with an information-theoretic model where labels emerge from computed property ranges
- All nodes are the same fundamental data structure; `type` is a **view**, not a structural category
- Documents three computed properties (scope, uncertainty, criticality), edge semantics with cycle policy, status values and transitions, and the compression principle
- Orchestration layer (Workflow, Step, Skill, Procedure) is unchanged

## Key concepts added

- **Compression model**: the hierarchy is a variable-rate code; decompose until uncertainty is low enough to act, not until you reach a fixed depth
- **Computed properties**: scope (subtree size), uncertainty (0.0–1.0 residual ambiguity), criticality (downstream impact)
- **Labels as property ranges**: "epic" = scope 3–20 + uncertainty < 0.5; guidelines for navigation, not enforcement gates
- **Edge cycle policy**: DependsOn/Parent cycles are pathological (Tarjan's SCC flags them); SoftDependsOn cycles are healthy (mutual reinforcement)
- **Status semantics**: "ready means all blockers resolved" — not merely "is a leaf"

## Test plan

- [ ] Read through new TAXONOMY.md for internal consistency
- [ ] Verify all property definitions match Phase 1 implementation in mem/graph.rs
- [ ] Verify cycle policy matches Phase 2 implementation in mem/graph_store.rs
- [ ] Check no other framework files contradict the new definitions

Closes: epic-b61a3ef9
Parent epic: task-aacc98b7 — Implement information-theoretic taxonomy redesign

🤖 Generated with [Claude Code](https://claude.com/claude-code)