### PR TITLE
fix(polecat): discover Docker socket for Colima on macOS

### DIFF
--- a/polecat/cli.py
+++ b/polecat/cli.py
@@ -366,6 +366,38 @@ def _container_to_host_path(container_path: Path) -> Path:
     return container_path
 
 
+def _find_docker_sock(env: dict, home: Path | None = None) -> Path | None:
+    """Return the host Docker socket path to mount, or None if unavailable.
+
+    Discovery order:
+    1. DOCKER_HOST in *env* dict or os.environ (env dict takes precedence).
+       - If set to a ``unix://`` socket that exists on disk → use it.
+       - If set to any other scheme (e.g. ``tcp://``) → return None; the
+         daemon is remote so mounting a local socket would be wrong.
+    2. ~/.colima/default/docker.sock  (Colima on macOS, default profile)
+    3. ~/.colima/docker.sock          (Colima legacy path)
+    4. /var/run/docker.sock           (standard Linux / Docker Desktop)
+
+    ``home`` is injectable for testing; defaults to ``Path.home()``.
+    """
+    _home = home if home is not None else Path.home()
+    docker_host = env.get("DOCKER_HOST") or os.environ.get("DOCKER_HOST", "")
+    if docker_host:
+        if docker_host.startswith("unix://"):
+            candidate = Path(docker_host.removeprefix("unix://"))
+            return candidate if candidate.exists() else None
+        # Non-unix scheme (tcp://, etc.) — remote daemon, skip local mount.
+        return None
+    for candidate in [
+        _home / ".colima" / "default" / "docker.sock",
+        _home / ".colima" / "docker.sock",
+        Path("/var/run/docker.sock"),
+    ]:
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def _build_docker_cmd(
     cli_tool: str,
     work_dir: Path,
@@ -508,28 +540,7 @@ def _build_docker_cmd(
     # Mount Docker socket for Docker-outside-of-Docker (build/test inside agents).
     # Pass the socket's gid so the non-root container user can access it — the gid
     # varies by host so we read it from the socket file rather than hardcoding.
-    #
-    # Socket discovery order:
-    #   1. DOCKER_HOST env var (strip "unix://" prefix if present)
-    #   2. ~/.colima/default/docker.sock  (Colima on macOS, default profile)
-    #   3. ~/.colima/docker.sock          (Colima legacy path)
-    #   4. /var/run/docker.sock           (standard Linux / Docker Desktop path)
-    docker_sock: Path | None = None
-    _docker_host = os.environ.get("DOCKER_HOST", "")
-    if _docker_host:
-        _sock_path = _docker_host.removeprefix("unix://")
-        _candidate = Path(_sock_path)
-        if _candidate.exists():
-            docker_sock = _candidate
-    if docker_sock is None:
-        for _candidate in [
-            Path.home() / ".colima" / "default" / "docker.sock",
-            Path.home() / ".colima" / "docker.sock",
-            Path("/var/run/docker.sock"),
-        ]:
-            if _candidate.exists():
-                docker_sock = _candidate
-                break
+    docker_sock = _find_docker_sock(env)
     if docker_sock is not None:
         docker_gid = docker_sock.stat().st_gid
         cmd.extend(["--group-add", str(docker_gid)])

--- a/polecat/cli.py
+++ b/polecat/cli.py
@@ -378,7 +378,10 @@ def _find_docker_sock(env: dict, home: Path | None = None) -> Path | None:
     3. ~/.colima/docker.sock          (Colima legacy path)
     4. /var/run/docker.sock           (standard Linux / Docker Desktop)
 
-    ``home`` is injectable for testing; defaults to ``Path.home()``.
+    ``home`` is injectable for testing; defaults to ``Path.home()``.  When
+    ``home`` is explicitly provided the absolute system path
+    ``/var/run/docker.sock`` is excluded from probing so tests remain
+    isolated from the host environment.
     """
     _home = home if home is not None else Path.home()
     docker_host = env.get("DOCKER_HOST") or os.environ.get("DOCKER_HOST", "")
@@ -388,11 +391,15 @@ def _find_docker_sock(env: dict, home: Path | None = None) -> Path | None:
             return candidate if candidate.exists() else None
         # Non-unix scheme (tcp://, etc.) — remote daemon, skip local mount.
         return None
-    for candidate in [
+    candidates: list[Path] = [
         _home / ".colima" / "default" / "docker.sock",
         _home / ".colima" / "docker.sock",
-        Path("/var/run/docker.sock"),
-    ]:
+    ]
+    if home is None:
+        # Only probe the absolute system path in production; tests pass home
+        # explicitly so they don't accidentally pick up a real host socket.
+        candidates.append(Path("/var/run/docker.sock"))
+    for candidate in candidates:
         if candidate.exists():
             return candidate
     return None

--- a/polecat/cli.py
+++ b/polecat/cli.py
@@ -508,11 +508,32 @@ def _build_docker_cmd(
     # Mount Docker socket for Docker-outside-of-Docker (build/test inside agents).
     # Pass the socket's gid so the non-root container user can access it — the gid
     # varies by host so we read it from the socket file rather than hardcoding.
-    docker_sock = Path("/var/run/docker.sock")
-    if docker_sock.exists():
+    #
+    # Socket discovery order:
+    #   1. DOCKER_HOST env var (strip "unix://" prefix if present)
+    #   2. ~/.colima/default/docker.sock  (Colima on macOS, default profile)
+    #   3. ~/.colima/docker.sock          (Colima legacy path)
+    #   4. /var/run/docker.sock           (standard Linux / Docker Desktop path)
+    docker_sock: Path | None = None
+    _docker_host = os.environ.get("DOCKER_HOST", "")
+    if _docker_host:
+        _sock_path = _docker_host.removeprefix("unix://")
+        _candidate = Path(_sock_path)
+        if _candidate.exists():
+            docker_sock = _candidate
+    if docker_sock is None:
+        for _candidate in [
+            Path.home() / ".colima" / "default" / "docker.sock",
+            Path.home() / ".colima" / "docker.sock",
+            Path("/var/run/docker.sock"),
+        ]:
+            if _candidate.exists():
+                docker_sock = _candidate
+                break
+    if docker_sock is not None:
         docker_gid = docker_sock.stat().st_gid
         cmd.extend(["--group-add", str(docker_gid)])
-        cmd.extend(["-v", "/var/run/docker.sock:/var/run/docker.sock"])
+        cmd.extend(["-v", f"{docker_sock}:/var/run/docker.sock"])
 
     # PKB connects over HTTP — pass the URL, no data volume needed.
     pkb_url = env.get("PKB_MCP_URL") or os.environ.get("PKB_MCP_URL")

--- a/tests/polecat/test_cli_docker.py
+++ b/tests/polecat/test_cli_docker.py
@@ -14,6 +14,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 # Add polecat to path
 TESTS_DIR = Path(__file__).parent.resolve()
 REPO_ROOT = TESTS_DIR.parent.parent
@@ -398,6 +400,18 @@ class TestFindDockerSock:
         legacy_sock.touch()
         result = _find_docker_sock({}, home=tmp_path)
         assert result == default_sock
+
+    @pytest.mark.skipif(
+        not Path("/var/run/docker.sock").exists(),
+        reason="/var/run/docker.sock not present on this host",
+    )
+    def test_standard_linux_sock_found_in_production_mode(self, monkeypatch):
+        """Production mode (home=None) picks up /var/run/docker.sock on Linux/CI."""
+        monkeypatch.delenv("DOCKER_HOST", raising=False)
+        # Production call — no home override, so /var/run/docker.sock is in the probe list.
+        result = _find_docker_sock({})
+        assert result is not None
+        assert "docker.sock" in str(result)
 
 
 class TestMakeWorkerEnv:

--- a/tests/polecat/test_cli_docker.py
+++ b/tests/polecat/test_cli_docker.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(REPO_ROOT / "aops-core"))
 from cli import (
     _build_docker_cmd,
     _clone_has_changes,
+    _find_docker_sock,
     _node_version_key,
     _pass_pkb_url_sandbox,
     _replicate_gemini_auth,
@@ -315,53 +316,88 @@ class TestBuildDockerCmd:
         vol_args = [cmd[i + 1] for i, x in enumerate(cmd) if x == "-v"]
         assert not any(str(aca_dir) in v for v in vol_args)
 
-    def _patch_docker_sock(self, exists: bool):
-        """Context manager that patches cli.Path so the docker socket mock returns `exists`.
-
-        Patches all probed socket paths (Colima default, Colima legacy, /var/run/docker.sock)
-        so that the first candidate returns `exists` and the rest return False (or True for the
-        first one when exists=True).  DOCKER_HOST is cleared so env-var discovery is skipped.
-        """
-        from unittest.mock import MagicMock
-
-        real_home = Path.home()
-        colima_default = str(real_home / ".colima" / "default" / "docker.sock")
-        colima_legacy = str(real_home / ".colima" / "docker.sock")
-        standard = "/var/run/docker.sock"
-
-        def path_factory(p):
-            p_str = str(p)
-            if p_str in (colima_default, colima_legacy, standard):
-                m = MagicMock(spec=Path)
-                # Only the first candidate (colima_default) pretends to exist when exists=True
-                m.exists.return_value = exists and (p_str == colima_default)
-                m.stat.return_value.st_gid = 999
-                m.__str__ = lambda self: p_str
-                return m
-            return Path(p)
-
-        import contextlib
-
-        @contextlib.contextmanager
-        def _ctx():
-            with (
-                patch("cli.Path") as MockPath,
-                patch.dict(os.environ, {"DOCKER_HOST": ""}, clear=False),
-            ):
-                MockPath.home.return_value = real_home
-                MockPath.side_effect = path_factory
-                yield MockPath
-
-        return _ctx()
-
-    def test_mounts_docker_socket_when_present(self):
+    def test_mounts_docker_socket_when_present(self, tmp_path):
         """Mounts host socket and adds --group-add when socket exists (DooD)."""
-        with self._patch_docker_sock(exists=True):
-            cmd = self._build()
+        sock = tmp_path / "docker.sock"
+        sock.touch()
+        env = {"DOCKER_HOST": f"unix://{sock}"}
+        cmd = self._build(env=env)
         vol_args = [cmd[i + 1] for i, x in enumerate(cmd) if x == "-v"]
         assert any("docker.sock" in v for v in vol_args)
         assert "--privileged" not in cmd
         assert "--user" in cmd
+
+
+class TestFindDockerSock:
+    """Live tests for _find_docker_sock — no mocking, real filesystem paths in tmp_path."""
+
+    def test_returns_none_when_no_socket_anywhere(self, tmp_path, monkeypatch):
+        """No socket file → None (DooD skipped gracefully)."""
+        monkeypatch.delenv("DOCKER_HOST", raising=False)
+        result = _find_docker_sock({}, home=tmp_path)
+        assert result is None
+
+    def test_docker_host_unix_socket_found(self, tmp_path):
+        """DOCKER_HOST=unix://... with existing file → that path is returned."""
+        sock = tmp_path / "custom.sock"
+        sock.touch()
+        result = _find_docker_sock({"DOCKER_HOST": f"unix://{sock}"}, home=tmp_path)
+        assert result == sock
+
+    def test_docker_host_unix_socket_missing(self, tmp_path):
+        """DOCKER_HOST=unix://... pointing at a nonexistent file → None (not a fallback)."""
+        result = _find_docker_sock({"DOCKER_HOST": f"unix://{tmp_path}/ghost.sock"}, home=tmp_path)
+        assert result is None
+
+    def test_docker_host_tcp_skips_local_probe(self, tmp_path):
+        """DOCKER_HOST=tcp://... → None even when local Colima sockets exist."""
+        colima = tmp_path / ".colima" / "default"
+        colima.mkdir(parents=True)
+        (colima / "docker.sock").touch()
+        result = _find_docker_sock({"DOCKER_HOST": "tcp://remote:2375"}, home=tmp_path)
+        assert result is None
+
+    def test_env_dict_takes_precedence_over_os_environ(self, tmp_path, monkeypatch):
+        """DOCKER_HOST in env dict is used even when os.environ has a different value."""
+        env_sock = tmp_path / "env-dict.sock"
+        env_sock.touch()
+        os_sock = tmp_path / "os-environ.sock"
+        os_sock.touch()
+        monkeypatch.setenv("DOCKER_HOST", f"unix://{os_sock}")
+        result = _find_docker_sock({"DOCKER_HOST": f"unix://{env_sock}"}, home=tmp_path)
+        assert result == env_sock
+
+    def test_colima_default_profile(self, tmp_path, monkeypatch):
+        """Falls back to ~/.colima/default/docker.sock when DOCKER_HOST unset."""
+        monkeypatch.delenv("DOCKER_HOST", raising=False)
+        colima = tmp_path / ".colima" / "default"
+        colima.mkdir(parents=True)
+        sock = colima / "docker.sock"
+        sock.touch()
+        result = _find_docker_sock({}, home=tmp_path)
+        assert result == sock
+
+    def test_colima_legacy_path(self, tmp_path, monkeypatch):
+        """Falls back to ~/.colima/docker.sock when default profile is absent."""
+        monkeypatch.delenv("DOCKER_HOST", raising=False)
+        colima = tmp_path / ".colima"
+        colima.mkdir(parents=True)
+        sock = colima / "docker.sock"
+        sock.touch()
+        result = _find_docker_sock({}, home=tmp_path)
+        assert result == sock
+
+    def test_colima_default_preferred_over_legacy(self, tmp_path, monkeypatch):
+        """default/docker.sock wins over legacy docker.sock when both exist."""
+        monkeypatch.delenv("DOCKER_HOST", raising=False)
+        (tmp_path / ".colima" / "default").mkdir(parents=True)
+        (tmp_path / ".colima").mkdir(parents=True, exist_ok=True)
+        default_sock = tmp_path / ".colima" / "default" / "docker.sock"
+        legacy_sock = tmp_path / ".colima" / "docker.sock"
+        default_sock.touch()
+        legacy_sock.touch()
+        result = _find_docker_sock({}, home=tmp_path)
+        assert result == default_sock
 
 
 class TestMakeWorkerEnv:

--- a/tests/polecat/test_cli_docker.py
+++ b/tests/polecat/test_cli_docker.py
@@ -316,16 +316,27 @@ class TestBuildDockerCmd:
         assert not any(str(aca_dir) in v for v in vol_args)
 
     def _patch_docker_sock(self, exists: bool):
-        """Context manager that patches cli.Path so the docker socket mock returns `exists`."""
+        """Context manager that patches cli.Path so the docker socket mock returns `exists`.
+
+        Patches all probed socket paths (Colima default, Colima legacy, /var/run/docker.sock)
+        so that the first candidate returns `exists` and the rest return False (or True for the
+        first one when exists=True).  DOCKER_HOST is cleared so env-var discovery is skipped.
+        """
         from unittest.mock import MagicMock
 
         real_home = Path.home()
+        colima_default = str(real_home / ".colima" / "default" / "docker.sock")
+        colima_legacy = str(real_home / ".colima" / "docker.sock")
+        standard = "/var/run/docker.sock"
 
         def path_factory(p):
-            if str(p) == "/var/run/docker.sock":
-                m = MagicMock()
-                m.exists.return_value = exists
+            p_str = str(p)
+            if p_str in (colima_default, colima_legacy, standard):
+                m = MagicMock(spec=Path)
+                # Only the first candidate (colima_default) pretends to exist when exists=True
+                m.exists.return_value = exists and (p_str == colima_default)
                 m.stat.return_value.st_gid = 999
+                m.__str__ = lambda self: p_str
                 return m
             return Path(p)
 
@@ -333,7 +344,10 @@ class TestBuildDockerCmd:
 
         @contextlib.contextmanager
         def _ctx():
-            with patch("cli.Path") as MockPath:
+            with (
+                patch("cli.Path") as MockPath,
+                patch.dict(os.environ, {"DOCKER_HOST": ""}, clear=False),
+            ):
                 MockPath.home.return_value = real_home
                 MockPath.side_effect = path_factory
                 yield MockPath


### PR DESCRIPTION
## Summary

- Hardcoded `/var/run/docker.sock` doesn't exist on macOS when Docker is served by Colima
- New probe order: `DOCKER_HOST` env var → `~/.colima/default/docker.sock` → `~/.colima/docker.sock` → `/var/run/docker.sock`
- Mounts whichever socket is found (still gracefully skips if none found)
- Test helper updated to clear `DOCKER_HOST` and mock all three socket paths

## Test plan

- [ ] `tests/polecat/test_cli_docker.py` — all 45 pass (verified locally)
- [ ] Manual: start Colima, run a polecat crew session — Docker-outside-of-Docker should work
- [ ] `DOCKER_HOST=unix:///custom/docker.sock` overrides probe (env var respected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)