### PR TITLE
fix(instructions): use correct update_task(updates={...}) object syntax

### DIFF
--- a/.agents/skills/framework/SKILL.md
+++ b/.agents/skills/framework/SKILL.md
@@ -236,7 +236,7 @@ Every task MUST follow this lifecycle. No shortcuts.
    - If no rule exists, propose one first
 
 3. UPDATE TASK AS YOU WORK (if tracking with task)
-   mcp__plugin_aops-core_tasks__update_task(id="<id>", body="[progress note]")
+   mcp__plugin_aops-core_tasks__update_task(id="<id>", updates={"body": "[progress note]"})
 
 4. ITERATION LOOP
    If implementation reveals plan was incomplete:

--- a/.agents/skills/framework/SKILL.md
+++ b/.agents/skills/framework/SKILL.md
@@ -174,11 +174,11 @@ Every task MUST follow this lifecycle. No shortcuts.
 
    IF task exists:
      mcp__plugin_aops-core_tasks__get_task(id="<id>")
-     mcp__plugin_aops-core_tasks__update_task(id="<id>", status="active")
+     mcp__plugin_aops-core_tasks__update_task(id="<id>", updates={"status": "active"})
 
    IF creating new tracked work:
      mcp__plugin_aops-core_tasks__create_task(task_title="[description]", type="task", project="aops", priority=2)
-     mcp__plugin_aops-core_tasks__update_task(id="<id>", status="active")
+     mcp__plugin_aops-core_tasks__update_task(id="<id>", updates={"status": "active"})
 
    IF quick ad-hoc work (< 15 min, no dependencies):
      Use TodoWrite for session tracking only

--- a/.agents/skills/framework/references/decision-briefing-details.md
+++ b/.agents/skills/framework/references/decision-briefing-details.md
@@ -31,8 +31,8 @@ mcp__plugin_aops-core_tasks__search_tasks(query="[query]")           # Search ta
 mcp__plugin_aops-core_tasks__get_blocked_tasks()                      # Tasks with unmet dependencies
 mcp__plugin_aops-core_tasks__list_tasks(status="active")              # Filter by status
 mcp__plugin_aops-core_tasks__complete_task(id="[ID]")                 # Complete task
-mcp__plugin_aops-core_tasks__update_task(id="[ID]", status="waiting") # Defer for later
-mcp__plugin_aops-core_tasks__update_task(id="[ID]", body="...")       # Add notes to task
+mcp__plugin_aops-core_tasks__update_task(id="[ID]", updates={"status": "waiting"}) # Defer for later
+mcp__plugin_aops-core_tasks__update_task(id="[ID]", updates={"body": "..."})       # Add notes to task
 ```
 
 ## Workflow
@@ -147,19 +147,19 @@ Parse user response and execute. Handle one decision at a time with verification
 ```python
 # For approved RFCs
 task = mcp__plugin_aops-core_tasks__get_task(id="[ID]")  # Verify still active
-mcp__plugin_aops-core_tasks__update_task(id="[ID]", body=task["body"] + "\n\nApproved by user [DATE]")
+mcp__plugin_aops-core_tasks__update_task(id="[ID]", updates={"body": task["body"] + "\n\nApproved by user [DATE]"})
 mcp__plugin_aops-core_tasks__complete_task(id="[ID]")
 # Note: Implementation task creation is SEPARATE work, not part of this workflow
 
 # For rejected RFCs
-mcp__plugin_aops-core_tasks__update_task(id="[ID]", body="Rejected: [user-provided reason if any]", status="cancelled")
+mcp__plugin_aops-core_tasks__update_task(id="[ID]", updates={"body": "Rejected: [user-provided reason if any]", "status": "cancelled"})
 
 # For deferred items
-mcp__plugin_aops-core_tasks__update_task(id="[ID]", status="waiting")
+mcp__plugin_aops-core_tasks__update_task(id="[ID]", updates={"status": "waiting"})
 
 # For prioritization decisions - add note documenting decision
 task = mcp__plugin_aops-core_tasks__get_task(id="[ID]")
-mcp__plugin_aops-core_tasks__update_task(id="[ID]", body=task["body"] + "\n\nUser decision [DATE]: [decision text]")
+mcp__plugin_aops-core_tasks__update_task(id="[ID]", updates={"body": task["body"] + "\n\nUser decision [DATE]: [decision text]"})
 ```
 
 **Error handling**: If any MCP call fails, report error and continue to next decision. Do not halt entire workflow for single failure.
@@ -247,8 +247,8 @@ Agent:
 1. mcp__plugin_aops-core_tasks__get_task(id="ns-p8n") → still active ✓
 2. mcp__plugin_aops-core_tasks__complete_task(id="ns-p8n")  # with approval note
 3. mcp__plugin_aops-core_tasks__get_task(id="ns-0ct") → still active ✓
-4. mcp__plugin_aops-core_tasks__update_task(id="ns-0ct", status="cancelled")
-5. mcp__plugin_aops-core_tasks__update_task(id="ns-tme", status="waiting")
+4. mcp__plugin_aops-core_tasks__update_task(id="ns-0ct", updates={"status": "cancelled"})
+5. mcp__plugin_aops-core_tasks__update_task(id="ns-tme", updates={"status": "waiting"})
 
 Reports: "Executed 3 decisions: ns-p8n approved, ns-0ct rejected, ns-tme deferred"
 ```

--- a/aops-core/commands/pull.md
+++ b/aops-core/commands/pull.md
@@ -27,14 +27,14 @@ permalink: commands/pull
 
 1. **List ready tasks**: Call `mcp__pkb__list_tasks(status="ready", limit=10)` to find ready tasks sorted by priority + downstream weight.
 2. **Select task**: Review the list and select the highest priority task (lowest priority number, e.g., P0).
-3. **Claim task**: Call `mcp__pkb__update_task(id="<task-id>", status="in_progress", assignee="polecat")` to claim it.
+3. **Claim task**: Call `mcp__pkb__update_task(id="<task-id>", updates={"status": "in_progress", "assignee": "polecat"})` to claim it.
 
 **If a specific task ID is provided** (`/pull <task-id>`):
 
 1. Call `mcp__pkb__get_task(id="<task-id>")` to load it.
 2. If the task has children (leaf=false), navigate to the first ready leaf subtask instead.
 3. If the task is already `in_progress`, skip claim and proceed directly to Step 1.5.
-4. Otherwise, claim with `mcp__pkb__update_task(id="<task-id>", status="in_progress", assignee="polecat")`.
+4. Otherwise, claim with `mcp__pkb__update_task(id="<task-id>", updates={"status": "in_progress", "assignee": "polecat"})`.
 
 **If no tasks are ready**:
 
@@ -137,7 +137,7 @@ Before proceeding to commit, verify the work produces **independent evidence** o
 For tasks with `type: learn`:
 
 1. **Investigate** per task instructions
-2. **Write findings to task body** - Use `update_task(id, body=...)` to append findings
+2. **Write findings to task body** - Use `update_task(id="<id>", updates={"body": "..."})` to append findings
 3. **Summarize in parent epic** - Read parent, append to "## Findings from Spikes"
 4. **Apply learnings to framework** - Before creating follow-up tasks, check if findings warrant direct changes to framework files (HEURISTICS.md, skill prompts, specs). Knowledge files alone are insufficient — if a learning points to a process improvement, change the process.
 5. **Decompose actionable items** - Create subtasks for remaining work that can't be done in this session. Resolve parent per [[references/hierarchy-quality-rules]]:
@@ -178,7 +178,7 @@ If task needs specific expertise or human judgment:
 ```
 mcp__pkb__update_task(
   id="<task-id>",
-  assignee="<role>"  # e.g., "nic", "polecat"
+  updates={"assignee": "<role>"}  # e.g., "nic", "polecat"
 )
 ```
 
@@ -236,8 +236,7 @@ If task is fundamentally unclear:
 ```
 mcp__pkb__update_task(
   id="<task-id>",
-  status="blocked",
-  body="Blocked: [specific questions]. Context: [what's known so far]."
+  updates={"status": "blocked", "body": "Blocked: [specific questions]. Context: [what's known so far]."}
 )
 ```
 

--- a/aops-core/commands/pull.md
+++ b/aops-core/commands/pull.md
@@ -137,7 +137,7 @@ Before proceeding to commit, verify the work produces **independent evidence** o
 For tasks with `type: learn`:
 
 1. **Investigate** per task instructions
-2. **Write findings to task body** - Use `update_task(id="<id>", updates={"body": "..."})` to append findings
+2. **Write findings to task body** - Use `mcp__pkb__append(id="<task-id>", content="...")` to record findings
 3. **Summarize in parent epic** - Read parent, append to "## Findings from Spikes"
 4. **Apply learnings to framework** - Before creating follow-up tasks, check if findings warrant direct changes to framework files (HEURISTICS.md, skill prompts, specs). Knowledge files alone are insufficient — if a learning points to a process improvement, change the process.
 5. **Decompose actionable items** - Create subtasks for remaining work that can't be done in this session. Resolve parent per [[references/hierarchy-quality-rules]]:

--- a/aops-core/skills/daily/instructions/focus-and-recommendations.md
+++ b/aops-core/skills/daily/instructions/focus-and-recommendations.md
@@ -217,4 +217,4 @@ Options: "Looks right" | "Out of sync" | "Need a reset"
 
 Ask: "Any of these ready to archive?"
 
-When user picks, use `mcp__pkb__update_task(id="<id>", status="cancelled")` to archive.
+When user picks, use `mcp__pkb__update_task(id="<id>", updates={"status": "cancelled"})` to archive.

--- a/aops-core/skills/remember/SKILL.md
+++ b/aops-core/skills/remember/SKILL.md
@@ -101,7 +101,7 @@ Is this about the user? (projects, goals, context, tasks)
 
 - Individual agent actions: "Completed X on DATE" → `mcp__pkb__create_task(task_title="...", type="task", project="<project>", parent="<parent-id>")`
 - Debugging logs: "Discovered bug in Y" → `mcp__pkb__create_task(task_title="...", type="task", project="<project>", parent="<parent-id>", tags=["bug"])`
-- Experiment step-by-step records: "Tried approach A" → `mcp__pkb__update_task(id="...", body="...")`
+- Experiment step-by-step records: "Tried approach A" → `mcp__pkb__update_task(id="...", updates={"body": "..."})`
 
 **Rule**: If it describes agent activity or debugging, it's operational episodic → tasks MCP.
 

--- a/aops-core/skills/supervisor/instructions/decomposition-and-review.md
+++ b/aops-core/skills/supervisor/instructions/decomposition-and-review.md
@@ -238,7 +238,7 @@ Parse responses into structured verdicts:
 Then:
 
 ```python
-update_task(id=task_id, status='waiting', body=synthesis_markdown)
+update_task(id=task_id, updates={"status": "waiting", "body": synthesis_markdown})
 ```
 
 **On NEEDS_REVISION**:
@@ -267,7 +267,7 @@ update_task(id=task_id, status='waiting', body=synthesis_markdown)
 Then:
 
 ```python
-update_task(id=task_id, status='active', body=synthesis_markdown)
+update_task(id=task_id, updates={"status": "active", "body": synthesis_markdown})
 # Re-enter Phase 1 with reviewer feedback
 ```
 
@@ -294,7 +294,7 @@ update_task(id=task_id, status='active', body=synthesis_markdown)
 Then:
 
 ```python
-update_task(id=task_id, status='blocked', body=synthesis_markdown)
+update_task(id=task_id, updates={"status": "blocked", "body": synthesis_markdown})
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Agents were passing `updates` as a JSON string or flat kwargs to `update_task`, causing "Missing required parameter: updates (object)" errors
- On retry agents would drop fields (like `body`), losing task completion summaries
- Updated all `update_task` examples across 6 source files to use correct `updates={...}` object wrapper

## Files changed
- `aops-core/commands/pull.md` — claim, body write, assignee, and block patterns
- `aops-core/skills/supervisor/instructions/decomposition-and-review.md` — waiting/active/blocked
- `aops-core/skills/daily/instructions/focus-and-recommendations.md` — cancel pattern
- `aops-core/skills/remember/SKILL.md` — body update pattern
- `.agents/skills/framework/SKILL.md` — status active pattern
- `.agents/skills/framework/references/decision-briefing-details.md` — all update_task examples

## Test plan
- [ ] Verify polecat `/pull` correctly claims tasks with `updates={"status": "in_progress", "assignee": "polecat"}`
- [ ] Verify `/dump` writes completion summary to task body via `updates={"status": "merge_ready", "body": "..."}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)