### PR TITLE
feat: use release_task for task completion in pull, dump, and polecat finish

### DIFF
--- a/.agents/skills/framework/references/forensics-details.md
+++ b/.agents/skills/framework/references/forensics-details.md
@@ -1,0 +1,211 @@
+---
+title: Session Hook Forensics — Detailed Procedures
+type: reference
+category: ref
+permalink: ref-forensics-details
+description: How to read hook JSONL logs, diagnose gate failures, trace session events, and correlate artifacts across the polecat system
+---
+
+# Session Hook Forensics — Detailed Procedures
+
+This reference provides the specific knowledge needed to diagnose hook and gate behavior from raw session artifacts. For hook architecture and I/O schemas, see [[hooks]]. For general framework debugging, see [[debug-details]].
+
+## Hook JSONL Schema
+
+Hook events are logged to `$AOPS_SESSIONS/hooks/<YYYYMMDD>-<session-short-hash>-hooks.jsonl` by `unified_logger.py`. Each line is a JSON object.
+
+### Key Fields
+
+| Field                | Type        | Description                                                                                                                                          |
+| -------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `session_id`         | string      | Full UUID                                                                                                                                            |
+| `session_short_hash` | string      | First 8 chars of UUID                                                                                                                                |
+| `hook_event`         | string      | `SessionStart`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `Stop`, `SubagentStart`, `SubagentStop`, `SessionEnd`, `PreCompact`, `Notification` |
+| `logged_at`          | string      | ISO 8601 timestamp                                                                                                                                   |
+| `exit_code`          | int         | 0=allow, 1=warn, 2=block                                                                                                                             |
+| `cwd`                | string      | Working directory at time of event                                                                                                                   |
+| `tool_name`          | string/null | Tool that triggered this event (PreToolUse/PostToolUse)                                                                                              |
+| `subagent_type`      | string/null | Agent type (SubagentStart/SubagentStop)                                                                                                              |
+| `output`             | object/null | **The gate verdict and messages** — see below                                                                                                        |
+
+### The `output` Field (CanonicalHookOutput)
+
+This is the most important field for forensics. Written by `unified_logger.py:69` as `output.model_dump()`.
+
+```json
+{
+  "verdict": "allow" | "deny" | null,
+  "system_message": "Text shown to agent or logged (may be null)",
+  "context_injection": "Text injected into agent context (may be null)",
+  "updated_input": null,
+  "metadata": { "source": "...", ... }
+}
+```
+
+- **`verdict`**: `"allow"` = gate passed, `"deny"` = gate blocked. On PreToolUse, deny means the tool call was rejected.
+- **`system_message`**: Human-readable message about gate state. Contains countdown markers (`◇ N`), gate status icons (`💧 ≡`), and blocking reasons.
+- **`context_injection`**: Instructions injected into the agent's context. Contains compliance check demands, skill routing tables, etc.
+
+### Known Transcript Gap
+
+**IMPORTANT**: The transcript parser (`transcript_parser.py:1764`) reads `data.get("hookSpecificOutput")` — a field from the Claude Code protocol that does NOT exist in hook JSONL. All `output` fields (verdicts, system_messages, context_injections) are silently dropped from generated transcripts. Until this parser bug is fixed, you **must read raw hook JSONL** for gate forensics. Do not trust transcripts for hook behavior.
+
+## File Locations & Cross-Referencing
+
+### Finding Files for a Session
+
+| Artifact              | Location                              | Pattern                                                   |
+| --------------------- | ------------------------------------- | --------------------------------------------------------- |
+| Hook JSONL            | `$AOPS_SESSIONS/hooks/`               | `<YYYYMMDD>-<session-short-hash>-hooks.jsonl`             |
+| Custodiet audit       | `$AOPS_SESSIONS/hooks/`               | `<YYYYMMDD>-<session-short-hash>-custodiet.md`            |
+| Session state         | `$AOPS_SESSION_STATE_DIR/`            | `<YYYYMMDD>-<HH>-<session-short-hash>.json`               |
+| Transcript (full)     | `$POLECAT_HOME/sessions/transcripts/` | `<YYYYMMDD>-<HH>-<worktree-name>-<session>-*-full.md`     |
+| Transcript (abridged) | `$POLECAT_HOME/sessions/transcripts/` | `<YYYYMMDD>-<HH>-<worktree-name>-<session>-*-abridged.md` |
+| CC session JSONL      | `~/.claude/projects/<project-dir>/`   | `<session-uuid>.jsonl`                                    |
+
+### Typical Paths on This Machine
+
+- `$AOPS_SESSIONS` = `/Users/suzor/.aops/sessions`
+- `$POLECAT_HOME` = `/Users/suzor/.aops`
+- `$AOPS_SESSION_STATE_DIR` = `/Users/suzor/.claude/projects/<project-dir>/`
+
+### Correlating Task → Session → Artifacts
+
+1. **Task → Session**: Polecat branches use `polecat/<task-id>` naming. Check `git log --all --oneline | grep <task-id>` to find the worktree.
+2. **Session → Hook JSONL**: Read the first line of the hook JSONL for `session_short_hash`, or match by date and session hash in the filename.
+3. **Session → Transcript**: Transcripts include the session short hash in the filename. Search: `ls $POLECAT_HOME/sessions/transcripts/ | grep <session-short-hash>`.
+
+## Gate Forensics
+
+### Custodiet / RBG Gate
+
+The compliance gate periodically requires the agent to invoke the rbg (formerly custodiet) subagent.
+
+**Configuration**:
+
+- Threshold: `CUSTODIET_TOOL_CALL_THRESHOLD` env var (default: **50 operations**)
+- Countdown starts: 7 operations before threshold (`start_before=7`)
+- Counter: tracks `ops_since_open` (incremented on PostToolUse for non-subagent calls)
+- Resets: when custodiet/rbg subagent completes (SubagentStop event)
+
+**IMPORTANT**: The gate counts **operations** (tool calls), NOT turns (user prompts). A single turn may produce 5-10 tool calls. "11 turns" ≈ 50 operations.
+
+**Diagnostic commands**:
+
+```bash
+# Count total operations in a session
+grep -c '"hook_event":"PostToolUse"' <hooks.jsonl>
+
+# Check if custodiet was dispatched (and how many times)
+grep -E '"hook_event":"SubagentSt' <hooks.jsonl> | \
+  python3 -c "
+import sys, json
+for line in sys.stdin:
+    d = json.loads(line.strip())
+    st = d.get('subagent_type', '')
+    if 'custodiet' in st or 'rbg' in st:
+        evt = d.get('hook_event')
+        v = d.get('output', {}).get('verdict')
+        print(f'{evt}: type={st}, verdict={v}')
+"
+
+# Check if custodiet blocked (verdict=deny on PreToolUse after threshold)
+grep '"hook_event":"PreToolUse"' <hooks.jsonl> | \
+  python3 -c "
+import sys, json
+for line in sys.stdin:
+    d = json.loads(line.strip())
+    out = d.get('output', {})
+    if out.get('verdict') == 'deny':
+        tool = d.get('tool_name', '?')
+        msg = str(out.get('system_message', ''))[:100]
+        print(f'BLOCKED: {tool} — {msg}')
+"
+```
+
+**What to look for**:
+
+- `SubagentStart` with `subagent_type` containing `custodiet` or `rbg` = gate check started
+- `SubagentStop` with same type + `verdict=allow` = gate cleared, counter reset
+- PreToolUse with `verdict=deny` and system_message mentioning "Compliance check" = gate blocking tools
+- Multiple SubagentStart/Stop pairs = gate firing repeatedly (normal in long sessions)
+
+### Stop / Handover Gate
+
+The Stop hook enforces session completion requirements (commit, handover, etc.).
+
+**Configuration**:
+
+- Handover gate: starts CLOSED when task bound, opens when `/dump` skill completes
+- Safety override: after **4 consecutive denies within 2 minutes**, auto-approves to prevent deadlock
+
+**Diagnostic commands**:
+
+```bash
+# Find all Stop events and their verdicts
+grep '"hook_event":"Stop"' <hooks.jsonl> | \
+  python3 -c "
+import sys, json
+for line in sys.stdin:
+    d = json.loads(line.strip())
+    out = d.get('output', {})
+    v = out.get('verdict', '?')
+    msg = str(out.get('system_message', ''))[:100]
+    ts = d.get('logged_at', '?')
+    print(f'{ts} verdict={v} msg={msg}')
+"
+```
+
+**What to look for**:
+
+- `verdict=deny` with `system_message` containing "Uncommitted changes" = handover gate blocking
+- 4 consecutive denies followed by `verdict=allow` = safety override fired (common pattern)
+- `verdict=allow` with no denies = session ended cleanly
+
+**The 4-deny pattern**: Many sessions show exactly 4 Stop denies before auto-approval. This is the safety override, not agent compliance. It means the agent either ignored or could not comply with the stop advice. Investigate the CC session JSONL to understand what the agent did between denies.
+
+## Identifying Polecat Sessions
+
+### By Working Directory
+
+Polecat worktree sessions have `cwd` containing `.claude/worktrees/`:
+
+```bash
+for f in $AOPS_SESSIONS/hooks/*.jsonl; do
+    head -1 "$f" 2>/dev/null | python3 -c "
+import sys, json
+try:
+    d = json.loads(sys.stdin.read())
+    cwd = d.get('cwd', '')
+    if 'worktree' in cwd:
+        print(f'{d.get(\"session_short_hash\")} | {d.get(\"logged_at\",\"?\")[:10]} | {cwd}')
+except: pass
+" 2>/dev/null
+done
+```
+
+### Claude vs Gemini
+
+- **Claude sessions**: Standard UUID session IDs (e.g., `fafa268a-7570-4284-...`)
+- **Gemini sessions**: Prefixed with `gemini-` (e.g., `gemini-20260405-abc12345`)
+- **Known gap**: The `model` and `client` fields in hook JSONL are currently `unknown` for all polecat sessions. The only reliable identifier is the session ID format.
+
+## Common Patterns
+
+### Pattern: Custodiet firing repeatedly in long sessions
+
+**Sessions**: `fafa268a` (193 ops, 10+ dispatches), `c7909ba1` (211 ops), `ac37cbc3` (268 ops)
+**Meaning**: Normal. Long sessions accumulate many operations. The gate fires every ~50 ops, custodiet evaluates, returns OK, counter resets, work continues.
+
+### Pattern: 4 Stop denies then auto-approve
+
+**Sessions**: `00d1f873`, `08a89782`, `0adf0325`, and many others
+**Meaning**: Agent tried to stop but had uncommitted changes. Ignored 3 denies. Safety override on 4th. Investigate whether the agent attempted to commit between denies or just retried Stop.
+
+### Pattern: Zero Gemini hook JSONL
+
+**As of 2026-04-09**: No Gemini-prefixed sessions exist in hook JSONL. Either Gemini polecats haven't been run with the current hook system, or the integration is broken. This is an open question.
+
+### Pattern: Operations vs turns confusion
+
+The gate threshold is 50 operations (tool calls), not 50 turns. A single user prompt can trigger 5-10+ tool calls. When someone says "the gate fired at 11 turns," it means ~50 operations happened across 11 prompts.

--- a/.agents/skills/framework/workflows/09-session-hook-forensics.md
+++ b/.agents/skills/framework/workflows/09-session-hook-forensics.md
@@ -12,34 +12,70 @@ description: Reconstruct session events from hooks logs to diagnose gate failure
 
 **Key principle**: Hooks logs record **every hook event** with full context. Session transcripts show the conversation; hooks logs show the infrastructure behavior.
 
-**Detailed procedures and examples**: See **[[forensics-details]]**.
+**Detailed procedures, schemas, and diagnostic commands**: See **[[forensics-details]]**.
 
 ## Quick Start
 
 ```bash
-# 1. Find recent sessions with hooks logs
-fd -l --newer 10m jsonl ~/.claude/projects
+# 1. Find the hooks log for a session
+ls $AOPS_SESSIONS/hooks/*<session-short-hash>*
 
-# 2. Generate transcript from session file
+# 2. Quick summary: how many ops, any denies?
+grep -c '"hook_event":"PostToolUse"' <hooks.jsonl>
+grep '"verdict":"deny"' <hooks.jsonl> | wc -l
+
+# 3. Generate transcript (for the conversation side)
 cd $AOPS && uv run python scripts/transcript.py <session.jsonl>
 
-# 3. Read the hooks log (last N entries)
-tail -20 <session-hooks.jsonl> | jq -c '.'
+# 4. Check gate verdicts (raw JSONL — transcripts don't show these yet)
+grep '"hook_event":"Stop"' <hooks.jsonl> | python3 -c "
+import sys, json
+for l in sys.stdin:
+    d = json.loads(l); o = d.get('output', {})
+    print(f'{d.get(\"logged_at\",\"?\")[:19]} verdict={o.get(\"verdict\")} msg={str(o.get(\"system_message\",\"\"))[:80]}')
+"
 ```
 
 ## Steps
 
-1. **Locate the Files**: Identify the session file and its corresponding hooks log.
-2. **Generate Transcript First**: Always use `transcript.py` on the session file for a readable log.
-3. **Analyze Hooks Log**: Filter for denied tool uses, hook errors, and event sequences using `jq`.
-4. **Reconstruct Event Sequence**: Focus on the last 3-5 events to identify failures at session end.
-5. **Diagnose Patterns**: Identify common issues like crashed gates, recursive loops, or missing gate requirements.
-6. **Create Bug Report**: Document the session ID, event sequence, root cause, and fix location.
+1. **Locate the Files**
+   - Hook JSONL: `$AOPS_SESSIONS/hooks/<YYYYMMDD>-<session-short-hash>-hooks.jsonl`
+   - Session state: `$AOPS_SESSION_STATE_DIR/<YYYYMMDD>-<HH>-<session-short-hash>.json`
+   - Transcript: `$POLECAT_HOME/sessions/transcripts/*<session-short-hash>*-full.md`
+   - See [[forensics-details]] for full path conventions and cross-reference guide.
+
+2. **Generate Transcript First**
+   Always use `transcript.py` on the CC session JSONL for a readable conversation log. But note: **transcripts currently do not show hook verdicts or system_messages** due to a parser bug (`transcript_parser.py:1764` reads wrong field). Use raw hook JSONL for gate behavior.
+
+3. **Check Gate Behavior**
+   - **Custodiet/RBG gate**: Grep for `SubagentStart`/`SubagentStop` with `custodiet` or `rbg` subagent type. Each pair = one compliance check. See [[forensics-details]] for commands.
+   - **Stop/Handover gate**: Grep for `"hook_event":"Stop"` and check `output.verdict`. Look for the 4-deny-then-auto-approve pattern.
+   - **PreToolUse blocks**: Grep for `"verdict":"deny"` to find any tool calls that were rejected.
+
+4. **Reconstruct Event Sequence**
+   Focus on the last 10-20 events to identify failures at session end. Key question: did the session complete its work, commit, invoke `/dump`, or get blocked?
+
+5. **Identify the Pattern**
+   Common patterns (see [[forensics-details]] for details):
+   - Custodiet dispatching repeatedly in long sessions (normal)
+   - 4 Stop denies then auto-approve (agent ignoring or unable to comply)
+   - Zero Gemini hook JSONL (open question as of 2026-04-09)
+   - Operations count ≠ turn count (50 ops ≈ 11 turns)
+
+6. **File Bug Report or Learning**
+   Document: session ID, event sequence, root cause, fix location. Use `/learn` for systemic issues.
+
+## Known Issues
+
+- **Transcript parser gap**: Hook `output` fields (verdict, system_message, context_injection) are not rendered in transcripts. The parser reads `hookSpecificOutput` (a CC protocol field) instead of `output` (our hook JSONL field). Until fixed, raw JSONL is the only source for gate forensics.
+- **Missing client_type**: Hook JSONL shows `model=unknown` for all polecat sessions. Distinguish Claude vs Gemini by session ID format only (`gemini-*` prefix for Gemini).
 
 ## Common Indicators
 
 - **`PostToolUse` crashes**: Gate updates failing after a tool completes.
-- **`verdict == "deny"`**: Explicitly blocked tool uses.
-- **Gate status markers**: `[📌✗ 💧✗ 🤝✓]` indicating specific gate states.
+- **`verdict == "deny"`**: Explicitly blocked tool uses or session stops.
+- **Gate status markers**: `◇` (custodiet countdown), `💧` (hydration), `≡` (gate status).
+- **`SubagentStart`/`SubagentStop` with custodiet/rbg**: Compliance gate check cycle.
+- **4 consecutive Stop denies**: Safety override pattern — investigate what happened between denies.
 
-**ALWAYS generate transcript first** - raw JSONL/JSON is difficult to interpret.
+**ALWAYS generate transcript first** — raw JSONL is difficult to interpret for the conversation side. But for hook/gate behavior, read the hook JSONL directly.

--- a/aops-core/commands/dump.md
+++ b/aops-core/commands/dump.md
@@ -14,7 +14,7 @@ needs_task: true
 mode: execution
 domain:
   - operations
-allowed-tools: Bash, mcp__pkb__create_memory, mcp__pkb__update_task, mcp__pkb__create_task, TodoWrite, AskUserQuestion, Read
+allowed-tools: Bash, mcp__pkb__create_memory, mcp__pkb__update_task, mcp__pkb__release_task, mcp__pkb__create_task, TodoWrite, AskUserQuestion, Read
 permalink: commands/dump
 ---
 
@@ -47,7 +47,17 @@ This command is **mandatory** before session end. The framework stop gate blocks
 Execute the [[base-handover]] workflow. The steps are:
 
 1. **Commit, push, and file a Pull Request** (MANDATORY per P#24)
-2. **Update task with progress** (or create historical task if none claimed)
+2. **Release task with progress** — use `release_task` to record what was done:
+   ```
+   mcp__pkb__release_task(
+     id="<task-id>",
+     status="merge_ready",
+     summary="What was done and outcome",
+     pr_url="https://github.com/..."
+   )
+   ```
+   If no PR was filed: use `status="review"` with `reason="session ended, work incomplete"`.
+   If no task was claimed, create a historical task first.
 3. **File follow-up tasks** for outstanding work — use [[decompose]] principles and ensure all have a **parent** set to the current task or epic
 4. **Persist discoveries to memory** (optional)
    4.5. **Codify learnings** — framework improvement → `gh issue create` in aops repo; project-scoped → update `./.agents/workflows/`; see [[references/handover-details]]

--- a/aops-core/commands/dump.md
+++ b/aops-core/commands/dump.md
@@ -58,6 +58,7 @@ Execute the [[base-handover]] workflow. The steps are:
    ```
    If no PR was filed: use `status="review"` with `reason="session ended, work incomplete"`.
    If no task was claimed, create a historical task first.
+   **Fallback**: If `mcp__pkb__release_task` is not available, use `mcp__pkb__update_task(id="<task-id>", updates={"status": "merge_ready"})`.
 3. **File follow-up tasks** for outstanding work — use [[decompose]] principles and ensure all have a **parent** set to the current task or epic
 4. **Persist discoveries to memory** (optional)
    4.5. **Codify learnings** — framework improvement → `gh issue create` in aops repo; project-scoped → update `./.agents/workflows/`; see [[references/handover-details]]

--- a/aops-core/commands/pull.md
+++ b/aops-core/commands/pull.md
@@ -282,6 +282,8 @@ mcp__pkb__release_task(id="<task-id>", status="merge_ready", summary="What was d
 
 This captures what was done so work history is never lost.
 
+**Fallback**: If `mcp__pkb__release_task` is not available, use `mcp__pkb__update_task(id="<task-id>", updates={"status": "done"})` or `mcp__pkb__complete_task(id="<task-id>")`.
+
 **Note**: TRIAGE path should halt before reaching Step 4. Only EXECUTE path tasks should be finished.
 
 ## Arguments

--- a/aops-core/commands/pull.md
+++ b/aops-core/commands/pull.md
@@ -13,7 +13,7 @@ needs_task: false
 mode: execution
 domain:
   - operations
-allowed-tools: Task, Bash, Read, Grep, Skill, AskUserQuestion, mcp__pkb__get_task, mcp__pkb__get_task_children, mcp__pkb__list_tasks, mcp__pkb__update_task, mcp__pkb__complete_task
+allowed-tools: Task, Bash, Read, Grep, Skill, AskUserQuestion, mcp__pkb__get_task, mcp__pkb__get_task_children, mcp__pkb__list_tasks, mcp__pkb__update_task, mcp__pkb__complete_task, mcp__pkb__release_task
 permalink: commands/pull
 ---
 
@@ -271,10 +271,16 @@ The PR review pipeline handles merge via GitHub auto-merge when a PR exists and 
 For tasks executed outside the polecat worktree system (e.g., direct `/pull` in a normal repo), use:
 
 ```
-mcp__pkb__complete_task(id="<task-id>")
+mcp__pkb__release_task(id="<task-id>", status="done", summary="What was done and outcome")
 ```
 
-This directly marks the task as `done` since there's no branch to merge.
+If you filed a PR, use `merge_ready` instead:
+
+```
+mcp__pkb__release_task(id="<task-id>", status="merge_ready", summary="What was done", pr_url="https://...")
+```
+
+This captures what was done so work history is never lost.
 
 **Note**: TRIAGE path should halt before reaching Step 4. Only EXECUTE path tasks should be finished.
 

--- a/polecat/cli.py
+++ b/polecat/cli.py
@@ -2117,17 +2117,69 @@ def finish(ctx, no_push, do_nuke, force, force_done):
     except Exception as e:
         print(f"  ⚠️  Unexpected error in PR integration: {e}")
 
-    # Update task status to merge_ready
+    # Release task with summary via PKB release_task
+    # Auto-generate summary from git diff stats
+    finish_summary = task.title
     try:
-        from lib.task_model import TaskStatus
+        stat_res = subprocess.run(
+            ["git", "diff", "--shortstat", "origin/main", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if stat_res.returncode == 0 and stat_res.stdout.strip():
+            finish_summary = f"{task.title}. Changes: {stat_res.stdout.strip()}"
+    except Exception:
+        pass
 
-        task.status = TaskStatus.MERGE_READY.value
-        manager.storage.save_task(task)
-    except ImportError:
-        from polecat.pkb_bridge import save_task as pkb_save
+    # Try to get PR URL
+    pr_url_str = None
+    try:
+        pr_res = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch_name,
+                "--state",
+                "open",
+                "--json",
+                "url",
+                "-q",
+                ".[0].url",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if pr_res.returncode == 0 and pr_res.stdout.strip():
+            pr_url_str = pr_res.stdout.strip()
+    except Exception:
+        pass
 
-        task.status = "merge_ready"
-        pkb_save(task)
+    try:
+        from polecat.pkb_bridge import release_task as pkb_release
+
+        pkb_release(
+            task_id,
+            status="merge_ready",
+            summary=finish_summary,
+            pr_url=pr_url_str,
+            branch=branch_name,
+        )
+    except Exception:
+        # Fallback to old path if release_task not available yet
+        try:
+            from lib.task_model import TaskStatus
+
+            task.status = TaskStatus.MERGE_READY.value
+            manager.storage.save_task(task)
+        except ImportError:
+            from polecat.pkb_bridge import save_task as pkb_save
+
+            task.status = "merge_ready"
+            pkb_save(task)
     print("✅ Task marked as 'merge_ready'")
     print(
         "📋 If a PR was created, the review pipeline will handle merge. See logs above for PR status."

--- a/polecat/pkb_bridge.py
+++ b/polecat/pkb_bridge.py
@@ -198,6 +198,31 @@ def update_task(task_id: str, **kwargs: Any) -> bool:
     return result is not None
 
 
+def release_task(
+    task_id: str,
+    status: str,
+    summary: str,
+    pr_url: str | None = None,
+    branch: str | None = None,
+    **kwargs: Any,
+) -> bool:
+    """Release a task via the PKB MCP server's release_task tool.
+
+    Captures what was done (summary) when transitioning to a handoff status.
+    Flat parameters — no nested objects.
+    """
+    params: dict[str, Any] = {"id": task_id, "status": status, "summary": summary}
+    if pr_url:
+        params["pr_url"] = pr_url
+    if branch:
+        params["branch"] = branch
+    for k, v in kwargs.items():
+        if v is not None:
+            params[k] = v
+    result = _get_client().call_tool("release_task", params)
+    return result is not None
+
+
 def save_task(task: PkbTask) -> bool:
     """Persist a mutated PkbTask back to PKB.
 


### PR DESCRIPTION
## Summary
- Agent instructions (`/pull`, `/dump`) updated to use `release_task` instead of `update_task` for task handoff
- `polecat finish` now calls `release_task` with auto-generated summary from git diff stats + PR URL lookup
- New `release_task()` Python bridge function in `pkb_bridge.py`

## Depends on
nicsuzor/mem feat/release-task branch (the PKB server must have the `release_task` tool)

## Test plan
- [ ] `/pull` completion step shows `release_task` examples
- [ ] `/dump` step 2 shows `release_task` with merge_ready status
- [ ] `polecat finish` on a test task writes summary + PR URL to task body
- [ ] Fallback path works when `release_task` tool not yet available on server

🤖 Generated with [Claude Code](https://claude.com/claude-code)