### PR TITLE
fix(commands): /pull and consumers pull from queued (taxonomy drift fix)

### DIFF
--- a/aops-core/commands/pull.md
+++ b/aops-core/commands/pull.md
@@ -19,24 +19,26 @@ permalink: commands/pull
 
 # /pull - Pull, Claim, and Complete a Task
 
-**Purpose**: Get a task from the ready queue, claim it (mark status active), and mark it complete when finished.
+**Purpose**: Get a task from the dispatch queue (status `queued`), claim it (mark status active), and mark it complete when finished.
 
 ## Workflow
 
 ### Step 1: Get and Claim a Task
 
-1. **List ready tasks**: Call `mcp__pkb__list_tasks(status="ready", limit=10)` to find ready tasks sorted by priority + downstream weight.
+Per [[TAXONOMY]] §Status Values: agents pull only from `queued` (the human-gated dispatch queue). Tasks in `ready` are decomposed-but-unapproved and MUST NOT be claimed here — the user promotes `ready` → `queued` manually.
+
+1. **List queued tasks**: Call `mcp__pkb__list_tasks(status="queued", limit=10)` to find dispatchable tasks sorted by priority + downstream weight.
 2. **Select task**: Review the list and select the highest priority task (lowest priority number, e.g., P0).
 3. **Claim task**: Call `mcp__pkb__update_task(id="<task-id>", status="in_progress", assignee="polecat")` to claim it.
 
 **If a specific task ID is provided** (`/pull <task-id>`):
 
 1. Call `mcp__pkb__get_task(id="<task-id>")` to load it.
-2. If the task has children (leaf=false), navigate to the first ready leaf subtask instead.
+2. If the task has children (leaf=false), navigate to the first queued leaf subtask instead.
 3. If the task is already `in_progress`, skip claim and proceed directly to Step 1.5.
 4. Otherwise, claim with `mcp__pkb__update_task(id="<task-id>", status="in_progress", assignee="polecat")`.
 
-**If no tasks are ready**:
+**If no tasks are queued**:
 
 - Check active/inbox tasks for any that can be worked on.
 - If none exist, report and halt.
@@ -287,8 +289,8 @@ This captures what was done so work history is never lost.
 
 ## Arguments
 
-- `/pull` - Get highest priority ready task from the global queue
-- `/pull <task-id>` - Claim a specific task (or its first ready leaf if it has children)
+- `/pull` - Get highest priority queued task from the global dispatch queue
+- `/pull <task-id>` - Claim a specific task (or its first queued leaf if it has children)
 
 ## Implementation Note
 

--- a/aops-core/commands/pull.md
+++ b/aops-core/commands/pull.md
@@ -2,7 +2,7 @@
 name: pull
 type: command
 category: instruction
-description: Pull a task from queue, claim it (mark active), and mark complete when done
+description: Pull a task from queue, claim it (mark in_progress), and mark complete when done
 triggers:
   - "pull task"
   - "get work"
@@ -19,7 +19,7 @@ permalink: commands/pull
 
 # /pull - Pull, Claim, and Complete a Task
 
-**Purpose**: Get a task from the dispatch queue (status `queued`), claim it (mark status active), and mark it complete when finished.
+**Purpose**: Get a task from the dispatch queue (status `queued`), claim it (mark status `in_progress`), and mark it complete when finished.
 
 ## Workflow
 

--- a/aops-core/skills/daily/instructions/focus-and-recommendations.md
+++ b/aops-core/skills/daily/instructions/focus-and-recommendations.md
@@ -25,6 +25,8 @@ summary = mcp__pkb__task_summary()
 `ready` = leaf tasks with claimable types (task/bug/feature), active status, all dependencies met.
 This is the ONLY consumer-facing view. Use `summary["ready"]` as the denominator for priority bars.
 
+> **Note (taxonomy)**: Daily planning legitimately surfaces `ready` (decomposed-but-not-yet-queued) tasks because the whole point of the daily review is to help the user decide what to promote from `ready` → `queued` for agent dispatch. See [[TAXONOMY]] §Status Values. Agent dispatch (`/pull`) pulls from `queued`, NOT `ready`.
+
 **Format**: `P0 ░░░░░░░░░░ 9/333` where:
 
 - `9` = `summary["by_priority"]["p0"]`


### PR DESCRIPTION
`aops-core/commands/pull.md` was calling `list_tasks(status="ready", limit=10)`, but per TAXONOMY.md:172 agents must pull only from `queued`. `ready` now means "decomposed, not yet human-approved" — pulling from `ready` defeats the supervisor/human gate by surfacing pre-approval tasks as dispatchable.

## Audit table (every grep hit in aops-core/)

| Site                                                                  | Intent                                 | Disposition                 | Rationale                                                                                                                                                                                                                              |
| --------------------------------------------------------------------- | -------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| aops-core/commands/pull.md:22 (Purpose)                               | dispatch (prose)                       | CHANGED → `queued`          | Described "ready queue" where intent is the dispatch queue.                                                                                                                                                                            |
| aops-core/commands/pull.md:28 (Step 1 heading + list_tasks call)      | dispatch                               | CHANGED → `queued`          | Primary drift: `list_tasks(status="ready", ...)` → `list_tasks(status="queued", ...)`. Also rewrote Step 1 heading "List ready tasks" → "List queued tasks" and added an inline reference to TAXONOMY §Status Values clarifying the gate. |
| aops-core/commands/pull.md (Step 1 "first ready leaf subtask")         | dispatch (navigating to a claimable leaf) | CHANGED → `queued`          | A `/pull <task-id>` that navigates to a descendant should land on a dispatchable leaf, not a pre-approval one.                                                                                                                         |
| aops-core/commands/pull.md ("If no tasks are ready")                  | dispatch                               | CHANGED → `queued`          | Consistency with the updated Step 1 semantics.                                                                                                                                                                                          |
| aops-core/commands/pull.md (Arguments section)                        | dispatch                               | CHANGED → `queued`          | "highest priority ready task from the global queue" → "highest priority queued task from the global dispatch queue".                                                                                                                   |
| aops-core/skills/daily/instructions/focus-and-recommendations.md:22,31,34 | decomposed-but-unapproved (daily planning) | LEFT as `ready` + clarifying note added | Daily focus legitimately surfaces `ready` tasks — the whole point is to help the user decide what to promote `ready` → `queued`. Added a one-paragraph note pointing to TAXONOMY and explicitly contrasting with `/pull` (which uses `queued`). |
| aops-core/HEURISTICS.md:74 ("multiple equivalent ready tasks")        | generic English, not a status query    | LEFT as-is                  | "ready" here is ordinary English meaning "available to work on"; not a `list_tasks` argument; no drift. Outside strict triage scope and would be noise to change.                                                                       |
| aops-core/skills/daily/SKILL.md:243 ("merge_ready tasks")             | unrelated status (`merge_ready`)       | LEFT as-is                  | Not a hit on `ready` as a standalone status — substring of `merge_ready`.                                                                                                                                                              |
| aops-core/skills/planner/SKILL.md:269-270 ("P0/P1 ready tasks", "Ready tasks within one project") | decomposed-but-unapproved (densify targets) | LEFT as-is                  | Planner densify strategies operate on decomposed-but-unapproved tasks (graph-building, not dispatch). Semantics already correct. Outside strict triage scope.                                                                          |
| aops-core/scripts/ensure-path.sh:38                                   | PATH-queuing, unrelated                | LEFT as-is                  | Shell script comment about deduplicating PATH entries. No connection to task status.                                                                                                                                                   |

## Sites flagged but NOT in this commit's scope

- `polecat/pkb_bridge.py:398` — `get_ready_tasks()` calls `list_tasks(status="ready", ...)`. This IS dispatch-intent and IS drift. However, it lives outside `aops-core/` (the grep scope defined in the brief) and modifying Python code in `polecat/` expands the change surface beyond the stated triage scope. Flagged for a follow-up task.
- `specs/pkb-server-spec.md:158`, `specs/strategic-triage.md:112` — these document `list_tasks(status="ready")` as the API for "the ready queue". These are specs describing behaviour and may themselves be drifted, but they are outside `aops-core/` and outside this task's scope.
- `tests/hooks/fixtures/gate_scenarios_live.json` — test fixture; per brief, no silent fixture changes.

## Test fixtures

No fixtures modified. `tests/hooks/fixtures/gate_scenarios_live.json` contains `status="ready"` strings inside fixture data — left untouched per brief.

Refs task-a15be971, epic task-98dbb46d.