### PR TITLE
fix(session_reader): recurse into project subdirs to discover Claude -workspace sessions

### DIFF
--- a/aops-core/lib/session_reader.py
+++ b/aops-core/lib/session_reader.py
@@ -1183,11 +1183,16 @@ def find_sessions(
                 # (Support both standard Claude and flat layouts)
                 potential_session_files = []
                 if claude_sessions_dir.exists():
-                    # Check for sessions in project subdirs
+                    # Check for sessions in project subdirs (and one level deeper for Claude -workspace layout)
                     for project_dir in claude_sessions_dir.iterdir():
                         if project_dir.is_dir() and not project_dir.name.endswith("-hooks"):
                             potential_session_files.extend(project_dir.glob("*.jsonl"))
                             potential_session_files.extend(project_dir.glob("*.json"))
+                            # Claude CLI stores sessions inside a project-hash subdir (e.g. -workspace/<uuid>.jsonl)
+                            for subdir in project_dir.iterdir():
+                                if subdir.is_dir() and not subdir.name.endswith("-hooks"):
+                                    potential_session_files.extend(subdir.glob("*.jsonl"))
+                                    potential_session_files.extend(subdir.glob("*.json"))
                     # Check for sessions directly in the dir
                     potential_session_files.extend(claude_sessions_dir.glob("*.jsonl"))
                     potential_session_files.extend(claude_sessions_dir.glob("*.json"))


### PR DESCRIPTION
## Problem

Claude polecat sessions are never discovered by `find_sessions()`, so transcripts are never generated for them. Gemini sessions work fine.

**Root cause:** Claude CLI stores session files one level deeper inside a project-hash subdirectory (e.g. `task-xxx/aops/-workspace/<uuid>.jsonl`). The existing glob in `session_reader.py` only checks the immediate `project_dir` level, missing these nested session files.

## Fix

Add a second level of iteration inside each `project_dir`: when scanning subdirs, also glob `*.jsonl`/`*.json` files from any child directory (respecting the existing `-hooks` exclusion). This matches the layout described in issue #669.

## Changes

- **`aops-core/lib/session_reader.py`** (6 lines added): recurse one level deeper into project subdirs to find Claude `-workspace` session files