### PR TITLE
docs: document target/goal alias, consequence, goals[] linking; fix stale daily-skill note

### DIFF
--- a/aops-core/skills/remember/references/TAXONOMY.md
+++ b/aops-core/skills/remember/references/TAXONOMY.md
@@ -116,13 +116,26 @@ The five primary node types in the PKB:
 
 | Type        | Description                                                                                                                          |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| **goal**    | A multi-month/year desired outcome — the root of the hierarchy                                                                       |
+| **goal**    | A multi-month/year desired outcome — the root of the hierarchy. Also stored as `type: target` (alias, same schema).                  |
 | **project** | A discrete thing we work on — a noun with defined scope and boundaries                                                               |
 | **epic**    | A bundle of related work that together achieves an aim — a verb                                                                      |
 | **task**    | A discrete deliverable, completable in a single focused session                                                                      |
 | **learn**   | Observational tracking — a spike, discovery, or noted finding. Not directly actionable; resolves by decomposing into follow-up tasks |
 
 The `classification` field carries additional semantic subtypes (bug, feature, spike, chore, etc.) without multiplying top-level types.
+
+### `target` nodes
+
+`target` is an alias for `goal`. Both represent user-declared strategic priorities with the same schema and computed properties. The distinction is stylistic — "goal" emphasises aspiration, "target" emphasises a concrete proof of achievement. Treat them identically in tooling and documentation.
+
+**Key fields on goal/target nodes:**
+
+| Field         | Description                                                                                                                                                                                 |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `consequence` | Prose description of what happens if this goal is not achieved. Present on tasks too — used by the daily skill to surface stakes without editorial framing.                                 |
+| `goals: []`   | List of goal/target IDs that a task or project contributes to. This is how work items link to goals — **not** via parent hierarchy. A task can contribute to multiple goals simultaneously. |
+
+**Why `goals: []` instead of parent edges?** Goals are cross-cutting: the same task may serve multiple strategic priorities. Parent edges encode containment; `goals: []` encodes contribution. The planner enforces this distinction — goals are never used as direct parents in the task tree.
 
 ---
 

--- a/aops-core/skills/remember/references/TAXONOMY.md
+++ b/aops-core/skills/remember/references/TAXONOMY.md
@@ -132,8 +132,8 @@ The `classification` field carries additional semantic subtypes (bug, feature, s
 
 | Field         | Description                                                                                                                                                                                 |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `consequence` | Prose description of what happens if this goal is not achieved. Present on tasks too — used by the daily skill to surface stakes without editorial framing.                                 |
-| `goals: []`   | List of goal/target IDs that a task or project contributes to. This is how work items link to goals — **not** via parent hierarchy. A task can contribute to multiple goals simultaneously. |
+| `consequence` | Prose description of what happens if the task or goal is not achieved. Present on tasks too — used by the daily skill to surface stakes without editorial framing.                          |
+| `goals: []`   | List of goal/target IDs that a task or project contributes to. This is how tasks and projects link to goals — not via parent hierarchy. A task can contribute to multiple goals simultaneously. |
 
 **Why `goals: []` instead of parent edges?** Goals are cross-cutting: the same task may serve multiple strategic priorities. Parent edges encode containment; `goals: []` encodes contribution. The planner enforces this distinction — goals are never used as direct parents in the task tree.
 

--- a/specs/effectual-planning-agent.md
+++ b/specs/effectual-planning-agent.md
@@ -286,6 +286,6 @@ Things we don't know yet and are planning to find out:
 
 4. **Historical value.** How much should we preserve vs. archive vs. delete? When is a dead project worth keeping?
 
-5. ~~**Daily skill alignment.**~~ **Resolved 2026-03-27.** The daily skill uses category-based recommendations (SHOULD/DEEP/ENJOY/QUICK/UNBLOCK) with PKB priority (P0-P4) as the ranking signal. Daily note "My priorities" is the SSoT for today-specific focus. The earlier intentions infrastructure (`intentions.yaml` and the `intention` tag) was removed — current "intent" is expressed as tasks with `priority: P1`; see `docs/VISION.md` for the rationale.
+5. ~~**Daily skill alignment.**~~ **Resolved 2026-03-27; updated 2026-04-25.** The earlier intentions infrastructure (`intentions.yaml` and the `intention` tag) was removed — current "intent" is expressed as tasks with `priority: P1`; see `docs/VISION.md` for the rationale. The SHOULD/DEEP/ENJOY/QUICK/UNBLOCK category-based recommendations were subsequently removed in PR #716 — the daily skill now reports facts only and does not rank or recommend. PKB priority (P0–P4) remains the task-ranking signal; `### My priorities` is the user-owned SSoT for today-specific focus.
 
 These are the assumptions we're testing by building and using the system.


### PR DESCRIPTION
## Summary

- **TAXONOMY.md**: Documents `target` as a `goal` alias (same schema, stylistic distinction), adds `consequence` and `goals: []` field documentation with rationale for why goals link via metadata not parent edges
- **effectual-planning-agent.md**: Corrects stale resolved-note — the original fix removed `intentions.yaml` but a later edit incorrectly stated SHOULD/DEEP/ENJOY/QUICK/UNBLOCK categories were still active; PR #716 removed them

## What was wrong

The `effectual-planning-agent.md` resolved note at item 5 said _"The daily skill uses category-based recommendations (SHOULD/DEEP/ENJOY/QUICK/UNBLOCK)"_ — this was accurate at the time of resolution (2026-03-27) but PR #716 subsequently removed all prioritisation from the daily skill. The note was never updated.

TAXONOMY.md had no documentation for `target` nodes (which exist in brain data with a consistent schema), the `consequence` field, or the `goals: []` linking pattern.

## Test plan

- [ ] TAXONOMY.md renders correctly; `target` section appears under Primary Node Types
- [ ] `effectual-planning-agent.md` item 5 no longer claims SHOULD/DEEP categories are active
- [ ] No other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)