### PR TITLE
Fix credential isolation: deferred shell + helper override; tighten /dump summary guidance

### DIFF
--- a/aops-core/hooks/session_env_setup.py
+++ b/aops-core/hooks/session_env_setup.py
@@ -42,6 +42,24 @@ def set_persistent_env(env_dict: dict[str, str]):
             print(f"WARNING: Failed to write to CLAUDE_ENV_FILE: {e}", file=sys.stderr)
 
 
+def append_shell_lines(lines: list[str]):
+    """Append raw shell lines to CLAUDE_ENV_FILE.
+
+    Unlike set_persistent_env, lines are written verbatim — no shell
+    quoting. Use this for shell-syntax constructs (conditional exports,
+    variable references) that must be evaluated at shell-source time.
+    """
+    if not lines:
+        return
+    if env_path := os.environ.get("CLAUDE_ENV_FILE"):
+        try:
+            with open(env_path, "a") as f:
+                for line in lines:
+                    f.write(line + "\n")
+        except Exception as e:
+            print(f"WARNING: Failed to append shell lines to CLAUDE_ENV_FILE: {e}", file=sys.stderr)
+
+
 def run_session_env_setup(ctx: HookContext, state: SessionState) -> GateResult | None:
     """Session start initialization - fail-fast checks and user messages.
 
@@ -161,23 +179,48 @@ def run_session_env_setup(ctx: HookContext, state: SessionState) -> GateResult |
         if not os.environ.get(var):
             persist[var] = val
 
-    # 6. Apply agent-env-map.conf credential isolation mappings (issue #581)
-    # (was step 5 before gate mode persistence was added)
-    from lib.agent_env import get_env_mapping_persist_dict
+    # 6. Apply agent-env-map.conf credential isolation mappings (issue #581).
+    # We split this into two pieces:
+    # - Literals (TARGET:=VALUE) and resolved env-to-env mappings go into the
+    #   `persist` dict for normal `export TARGET=value` writes.
+    # - Env-to-env mappings (TARGET=SOURCE) are ALSO written as deferred shell
+    #   exports via append_shell_lines (see step 6c). This handles the case
+    #   where SOURCE is set by the user's shell profile (e.g., ~/.zshenv) and
+    #   thus visible to the shell-snapshot-sourced bash, but NOT to the
+    #   Python hook (which inherits the launchd env on macOS Claude Desktop).
+    #   Without this, `GH_TOKEN=AOPS_BOT_GH_TOKEN` silently skipped because the
+    #   hook saw AOPS_BOT_GH_TOKEN as unset, even though the shell saw it.
+    from lib.agent_env import (
+        get_env_mapping_persist_dict,
+        get_env_mapping_shell_lines,
+    )
 
     persist.update(get_env_mapping_persist_dict())
 
-    # 6b. Force SSH→HTTPS rewrite for GitHub URLs (defense-in-depth).
-    # On macOS, SSH_AUTH_SOCK="" is insufficient — Keychain-stored keys
-    # bypass ssh-agent entirely. GIT_SSH_COMMAND=false (from agent-env-map)
-    # blocks SSH auth, but git would still *attempt* SSH and fail rather
-    # than falling through to HTTPS. The insteadOf rewrite ensures git
-    # never tries SSH at all, using GH_TOKEN via HTTPS credential helper.
-    persist["GIT_CONFIG_COUNT"] = "2"
+    # 6b. Force SSH→HTTPS rewrite for GitHub URLs AND override the credential
+    # helper for github.com so the user's `~/.gitconfig` host-specific helper
+    # (`!gh auth git-credential`) doesn't shadow the bot-PAT helper.
+    #
+    # On macOS, SSH_AUTH_SOCK="" is insufficient — Keychain-stored keys bypass
+    # ssh-agent entirely. GIT_SSH_COMMAND=false blocks SSH auth, but git would
+    # still attempt SSH; the insteadOf rewrite ensures it goes straight to
+    # HTTPS. Then the credential.https://github.com.helper override resets any
+    # inherited helper (the empty value) and installs a single bot-PAT helper.
+    # Git treats `helper` as list-typed, so an empty value clears the prior
+    # list before the next entry is appended.
+    persist["GIT_CONFIG_COUNT"] = "4"
     persist["GIT_CONFIG_KEY_0"] = "url.https://github.com/.insteadOf"
     persist["GIT_CONFIG_VALUE_0"] = "git@github.com:"
     persist["GIT_CONFIG_KEY_1"] = "url.https://github.com/.insteadOf"
     persist["GIT_CONFIG_VALUE_1"] = "ssh://git@github.com/"
+    persist["GIT_CONFIG_KEY_2"] = "credential.https://github.com.helper"
+    persist["GIT_CONFIG_VALUE_2"] = ""
+    persist["GIT_CONFIG_KEY_3"] = "credential.https://github.com.helper"
+    persist["GIT_CONFIG_VALUE_3"] = (
+        '!f() { test "$1" = get && '
+        'printf "username=x-access-token\\npassword=%s\\n" '
+        '"${GH_TOKEN:-${GITHUB_TOKEN:-${AOPS_BOT_GH_TOKEN}}}"; }; f'
+    )
 
     # 7. Ensure required CLIs (uv, gh, etc.) are accessible in PATH.
     # Centralised in lib/path_bootstrap — shared logic with ensure-path.sh.
@@ -246,11 +289,26 @@ Today's note has not been populated yet. Run `/daily` to update.
         # Graceful degradation for daily note bootstrap
         messages.append(f"Daily note: bootstrap failed ({e})")
 
-    # Persist all environment variables
+    # Persist all resolved environment variables (literals and any env-to-env
+    # mappings that resolved at hook time).
     set_persistent_env(persist)
+
+    # 6c. Write deferred-shell exports for env-to-env mappings so SOURCE vars
+    # set by the user's shell snapshot (e.g., AOPS_BOT_GH_TOKEN from ~/.zshenv)
+    # propagate to TARGET. These lines append AFTER set_persistent_env's writes,
+    # so they overwrite/refine the resolved values when the shell evaluates.
+    shell_lines = get_env_mapping_shell_lines()
+    if shell_lines:
+        append_shell_lines(
+            ["# agent-env-map.conf: deferred-shell exports (issue #581)", *shell_lines]
+        )
 
     return GateResult(
         verdict=GateVerdict.ALLOW,
         system_message="\n".join(messages),
-        metadata={"source": "session_env_setup", "persisted_vars": persist},
+        metadata={
+            "source": "session_env_setup",
+            "persisted_vars": persist,
+            "deferred_shell_lines": shell_lines,
+        },
     )

--- a/aops-core/lib/agent_env.py
+++ b/aops-core/lib/agent_env.py
@@ -144,3 +144,40 @@ def get_env_mapping_persist_dict(
         Dict of {TARGET: value} to persist.
     """
     return apply_env_mappings(env={}, config_path=config_path, source_env=source_env)
+
+
+def get_env_mapping_shell_lines(
+    config_path: Path | str | None = None,
+) -> list[str]:
+    """Return shell `export` lines for agent-env-map.conf entries.
+
+    Unlike `get_env_mapping_persist_dict()`, these lines defer SOURCE
+    resolution to shell-evaluation time. This matters when the SOURCE
+    var is set by the user's shell profile (e.g., AOPS_BOT_GH_TOKEN
+    from ~/.zshenv) and is therefore visible to the post-snapshot
+    shell but NOT to the Python hook that writes CLAUDE_ENV_FILE
+    (which inherits the launchd env, not the shell env).
+
+    Output format:
+      - Literal (TARGET:=VALUE):  export TARGET='VALUE'
+      - Literal empty (TARGET:=): unset TARGET 2>/dev/null; export TARGET=''
+      - Mapping (TARGET=SOURCE):  [ -n "${SOURCE+x}" ] && export TARGET="${SOURCE}"
+        (Conditional: only set TARGET if SOURCE exists, even if empty.)
+
+    Returns:
+        List of shell-syntax lines suitable for CLAUDE_ENV_FILE.
+    """
+    import shlex
+
+    lines: list[str] = []
+    for entry in load_env_entries(config_path):
+        if entry.is_literal:
+            lines.append(f"export {entry.target}={shlex.quote(entry.value)}")
+        else:
+            # Defer SOURCE resolution to shell time. ${SOURCE+x} is set
+            # iff SOURCE is defined (even if empty), which mirrors the
+            # `is not None` check in apply_env_mappings.
+            lines.append(
+                f'[ -n "${{{entry.value}+x}}" ] && export {entry.target}="${{{entry.value}}}"'
+            )
+    return lines

--- a/aops-core/lib/agent_env.py
+++ b/aops-core/lib/agent_env.py
@@ -158,26 +158,26 @@ def get_env_mapping_shell_lines(
     shell but NOT to the Python hook that writes CLAUDE_ENV_FILE
     (which inherits the launchd env, not the shell env).
 
-    Output format:
-      - Literal (TARGET:=VALUE):  export TARGET='VALUE'
-      - Literal empty (TARGET:=): unset TARGET 2>/dev/null; export TARGET=''
+    Literals (TARGET:=VALUE) are excluded — they are already written verbatim
+    by `get_env_mapping_persist_dict()` / `set_persistent_env()` at hook time,
+    so there is no need to defer them.
+
+    Output format (env-to-env mappings only):
       - Mapping (TARGET=SOURCE):  [ -n "${SOURCE+x}" ] && export TARGET="${SOURCE}"
         (Conditional: only set TARGET if SOURCE exists, even if empty.)
 
     Returns:
         List of shell-syntax lines suitable for CLAUDE_ENV_FILE.
     """
-    import shlex
-
     lines: list[str] = []
     for entry in load_env_entries(config_path):
         if entry.is_literal:
-            lines.append(f"export {entry.target}={shlex.quote(entry.value)}")
-        else:
-            # Defer SOURCE resolution to shell time. ${SOURCE+x} is set
-            # iff SOURCE is defined (even if empty), which mirrors the
-            # `is not None` check in apply_env_mappings.
-            lines.append(
-                f'[ -n "${{{entry.value}+x}}" ] && export {entry.target}="${{{entry.value}}}"'
-            )
+            # Already handled by get_env_mapping_persist_dict(); skip.
+            continue
+        # Defer SOURCE resolution to shell time. ${SOURCE+x} is set
+        # iff SOURCE is defined (even if empty), which mirrors the
+        # `is not None` check in apply_env_mappings.
+        lines.append(
+            f'[ -n "${{{entry.value}+x}}" ] && export {entry.target}="${{{entry.value}}}"'
+        )
     return lines

--- a/aops-core/lib/agent_env.py
+++ b/aops-core/lib/agent_env.py
@@ -177,7 +177,5 @@ def get_env_mapping_shell_lines(
         # Defer SOURCE resolution to shell time. ${SOURCE+x} is set
         # iff SOURCE is defined (even if empty), which mirrors the
         # `is not None` check in apply_env_mappings.
-        lines.append(
-            f'[ -n "${{{entry.value}+x}}" ] && export {entry.target}="${{{entry.value}}}"'
-        )
+        lines.append(f'[ -n "${{{entry.value}+x}}" ] && export {entry.target}="${{{entry.value}}}"')
     return lines

--- a/aops-core/skills/end_session/SKILL.md
+++ b/aops-core/skills/end_session/SKILL.md
@@ -78,7 +78,23 @@ Use **Full-form** in **every other case**, including: task complete, end-of-day 
    ```
 
    - **No task bound?** `release_task` auto-creates a minimal ad-hoc task under the `adhoc-sessions` root ([[T4]]). Until T4 lands, fall back to `create_task` first, then `release_task` on the new id.
-   - **`release_summary` quality**: result-oriented ("Implemented YAML schema extension for session handover"), not activity-oriented ("I worked on the schema"). This is the primary signal for the Recent Sessions dashboard.
+   - **`release_summary` quality**: this field is the primary signal for the Recent Sessions dashboard, where it appears in a long stack of unrelated handovers from other sessions. **Write it for that audience — a future reader who has none of this session's context.**
+
+     Three requirements:
+
+     1. **Result-oriented**, not activity-oriented. "Implemented YAML schema extension for session handover", not "I worked on the schema".
+     2. **Self-contained**. Every artifact you reference must carry enough description that the reader can identify it without opening the session. Name things: which workflow, which incident, which agent, which file, which issue#. References by role alone ("the enforcer", "the orchestrator", "the flag", "the failure") are useless out of context — name what specifically.
+     3. **Concrete IDs with description**. Issue and PR references must be `org/repo#NNN` AND a phrase saying what the issue/PR is about, so the line is parseable without clicking through.
+
+     Bad (real example, do not write summaries like this):
+     > Root cause analysis completed. Identified the failure as instruction-weighting + detection-failure (enforcer had discretionary language and chose not to block; orchestrator should have treated the flag as actionable). GitHub issue filed.
+
+     Why it's bad: which failure? which enforcer? which orchestrator? which flag? which issue? In a stack of 30 handovers, this conveys nothing.
+
+     Good:
+     > Root-caused why agent-merge-prep silently approved 3 PRs on 2026-04-25 without enforcer veto. Cause: enforcer prompt said "consider blocking" (discretionary) and the orchestrator treated WARN as ALLOW. Filed nicsuzor/academicOps#612 (harden enforcer language + orchestrator WARN handling).
+
+     Length budget: ≤ 500 chars. Tight is fine. Cryptic is not.
    - **Follow-ups**: every concrete future action must be a real PKB task before you list it here. Do not put bullet prose into `release_summary` or session notes — the dashboard and `/recap` only see structured fields.
    - **Fallback**: if `release_task` is unavailable, `update_task(id=..., status="merge_ready")` keeps the supervisor unblocked, but the dashboard loses this session.
    - **Polecat note**: calling `release_task` with a terminal status is what lets the polecat supervisor detect termination via PKB polling. Skipping this leaves Gemini workers running until external timeout (#521).
@@ -93,11 +109,13 @@ Use **Full-form** in **every other case**, including: task complete, end-of-day 
    - **PR**: <url>
    - **Branch**: `<branch>`
    - **Issue**: <url or "none">
-   - **Follow-ups**: `<task-id>`, `<task-id>` (or "none")
-   - **Summary**: <release_summary value>
+   - **Follow-ups**: `<task-id> (<short title>)`, `<task-id> (<short title>)` (or "none")
+   - **Summary**: <release_summary value — must satisfy the self-contained quality bar above>
    ```
 
    Omit `PR` and `Issue` lines if not set. Omit `Follow-ups` if empty. Do not add any prose before or after the block.
+
+   Follow-up task IDs must each carry a short parenthetical title for the same reason `release_summary` must — a stack-of-handovers reader can't resolve `task-0f7d3877` without it.
 
 4. **Halt.** Nothing follows the handover block.
 

--- a/tests/integration/test_credential_isolation.py
+++ b/tests/integration/test_credential_isolation.py
@@ -423,7 +423,13 @@ class TestCredentialBridgeHook:
         )
 
     def test_hook_does_not_map_when_bot_token_absent(self, temp_env_file):
-        """When AOPS_BOT_GH_TOKEN is not set, hook should not write GH_TOKEN."""
+        """When AOPS_BOT_GH_TOKEN is not set anywhere (hook env nor shell),
+        sourcing the env file must NOT export GH_TOKEN/GITHUB_TOKEN.
+
+        The hook now uses deferred shell expansion (so the env file does
+        contain a conditional line referencing GH_TOKEN), but the conditional
+        must skip when the source variable is absent at source-time.
+        """
         ctx = HookContext(
             session_id="test-cred-no-bot",
             session_short_hash="nobot123",
@@ -444,9 +450,28 @@ class TestCredentialBridgeHook:
         ):
             run_session_env_setup(ctx, state)
 
-        content = temp_env_file.read_text()
-        assert "GH_TOKEN" not in content, (
-            f"Hook should NOT write GH_TOKEN when AOPS_BOT_GH_TOKEN is absent.\nGot: {content}"
+        # Source the env file in a clean bash subshell with AOPS_BOT_GH_TOKEN
+        # explicitly unset, then check GH_TOKEN/GITHUB_TOKEN are still unset.
+        result = subprocess.run(
+            [
+                "/bin/bash",
+                "-c",
+                f"unset AOPS_BOT_GH_TOKEN GH_TOKEN GITHUB_TOKEN; "
+                f"source {temp_env_file}; "
+                f"echo GH_SET=${{GH_TOKEN+yes}} GITHUB_SET=${{GITHUB_TOKEN+yes}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        assert "GH_SET=yes" not in result.stdout, (
+            f"GH_TOKEN must NOT be exported when AOPS_BOT_GH_TOKEN is absent.\n"
+            f"Output: {result.stdout!r}"
+        )
+        assert "GITHUB_SET=yes" not in result.stdout, (
+            f"GITHUB_TOKEN must NOT be exported when AOPS_BOT_GH_TOKEN is absent.\n"
+            f"Output: {result.stdout!r}"
         )
 
     def test_hook_overrides_existing_personal_token(self, temp_env_file, credential_markers):
@@ -572,3 +597,170 @@ class TestSubprocessCredentialIsolation:
         assert result.stdout.strip() == "0", (
             f"GIT_TERMINAL_PROMPT should be '0', got: {result.stdout.strip()!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Deferred-shell exports: handles the macOS-Claude-Desktop case where
+# AOPS_BOT_GH_TOKEN is set in the user's shell snapshot (~/.zshenv) but NOT
+# in the launchd env that the Python hook sees. The persist dict path silently
+# skipped GH_TOKEN/GITHUB_TOKEN; the shell-lines path defers resolution so
+# the shell snapshot's value is picked up at source-time.
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredShellLines:
+    def test_shell_lines_defer_env_to_env(self):
+        """Env-to-env mappings produce shell-conditional exports."""
+        from lib.agent_env import get_env_mapping_shell_lines
+
+        lines = get_env_mapping_shell_lines()
+        gh_line = next((line for line in lines if "GH_TOKEN=" in line), None)
+        assert gh_line is not None, "GH_TOKEN export must be present"
+        assert "${AOPS_BOT_GH_TOKEN+x}" in gh_line, (
+            "Must use ${SOURCE+x} for is-set check (defer to shell)"
+        )
+        assert '"${AOPS_BOT_GH_TOKEN}"' in gh_line, (
+            "Must reference ${SOURCE} for value (defer to shell)"
+        )
+
+    def test_shell_lines_emit_literals_directly(self):
+        """Literals are written as direct exports, not deferred references."""
+        from lib.agent_env import get_env_mapping_shell_lines
+
+        lines = get_env_mapping_shell_lines()
+        ssh_line = next((line for line in lines if "SSH_AUTH_SOCK" in line), None)
+        assert ssh_line is not None
+        # Literal empty value: `export SSH_AUTH_SOCK=''`
+        assert ssh_line.strip() == "export SSH_AUTH_SOCK=''"
+
+    def test_shell_lines_resolve_via_bash(self, credential_markers):
+        """Bash-evaluating the shell lines must populate GH_TOKEN/GITHUB_TOKEN.
+
+        Reproduces the macOS-Claude-Desktop scenario: Python hook sees no
+        AOPS_BOT_GH_TOKEN, but the shell snapshot does. The deferred lines
+        must pick up the shell value when sourced.
+        """
+        from lib.agent_env import get_env_mapping_shell_lines
+
+        bot = credential_markers["bot"]
+        lines = get_env_mapping_shell_lines()
+        script = "\n".join(lines)
+
+        # Simulate the shell-snapshot setting AOPS_BOT_GH_TOKEN, then sourcing
+        # the deferred-export lines, then printing GH_TOKEN/GITHUB_TOKEN.
+        full = f'export AOPS_BOT_GH_TOKEN={bot}\n{script}\nprintf \'%s\\n%s\\n\' "$GH_TOKEN" "$GITHUB_TOKEN"\n'
+        result = subprocess.run(
+            ["/bin/bash", "-c", full], capture_output=True, text=True, timeout=10, check=True
+        )
+        gh, github = result.stdout.strip().split("\n")
+        assert gh == bot, "GH_TOKEN must resolve to bot value via deferred shell expansion"
+        assert github == bot, "GITHUB_TOKEN must resolve too"
+
+    def test_shell_lines_skip_when_source_unset(self):
+        """When SOURCE is unset, shell lines must not export an empty TARGET.
+
+        Avoids the regression where GH_TOKEN gets set to empty string,
+        causing gh CLI to fall through to keyring auth.
+        """
+        from lib.agent_env import get_env_mapping_shell_lines
+
+        lines = get_env_mapping_shell_lines()
+        script = "\n".join(lines)
+
+        # No AOPS_BOT_GH_TOKEN in env: GH_TOKEN should remain unset.
+        full = (
+            f'unset AOPS_BOT_GH_TOKEN\n{script}\nprintf "GH_TOKEN_SET=%s\\n" "${{GH_TOKEN+yes}}"\n'
+        )
+        result = subprocess.run(
+            ["/bin/bash", "-c", full], capture_output=True, text=True, timeout=10, check=True
+        )
+        assert "GH_TOKEN_SET=" in result.stdout
+        assert "GH_TOKEN_SET=yes" not in result.stdout, (
+            "GH_TOKEN must NOT be exported when AOPS_BOT_GH_TOKEN is unset"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Credential helper override: plugs the host-specific helper precedence bug
+# (~/.gitconfig: credential.https://github.com.helper = !gh auth git-credential).
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialHelperOverride:
+    def test_session_env_setup_writes_helper_override(self, tmp_path, monkeypatch):
+        """SessionStart must write GIT_CONFIG_KEY_2/3 reset+install for github.com helper."""
+        env_file = tmp_path / "env.sh"
+        env_file.touch()
+        monkeypatch.setenv("CLAUDE_ENV_FILE", str(env_file))
+        monkeypatch.setenv("AOPS_BOT_GH_TOKEN", "ghp_dummy_for_test")
+
+        ctx = HookContext(
+            session_id=str(uuid.uuid4()),
+            trace_id=str(uuid.uuid4()),
+            hook_event="SessionStart",
+            transcript_path="/tmp/test-transcript.jsonl",
+            cwd=str(tmp_path),
+            raw_input={"source": "startup"},
+        )
+        state = SessionState.create(session_id=ctx.session_id)
+        run_session_env_setup(ctx, state)
+
+        contents = env_file.read_text()
+        assert "GIT_CONFIG_COUNT=4" in contents, (
+            "GIT_CONFIG_COUNT must be 4 to enable both insteadOf and helper override"
+        )
+        # Reset entry then install entry — list-typed helper requires reset first
+        helper_keys = [
+            line
+            for line in contents.splitlines()
+            if "GIT_CONFIG_KEY_2" in line or "GIT_CONFIG_KEY_3" in line
+        ]
+        assert len(helper_keys) == 2
+        assert all("credential.https://github.com.helper" in line for line in helper_keys)
+        # Reset value must be empty
+        assert "GIT_CONFIG_VALUE_2=''" in contents
+        # Install value must contain the bot-PAT printf
+        assert 'printf "username=x-access-token' in contents
+
+    def test_helper_override_resolves_via_git(self, tmp_path, credential_markers):
+        """The helper override must produce the bot identity when git asks for credentials."""
+        bot = credential_markers["bot"]
+
+        # Build the same env layout session_env_setup writes.
+        env = os.environ.copy()
+        env["GH_TOKEN"] = bot
+        env["GITHUB_TOKEN"] = bot
+        env["AOPS_BOT_GH_TOKEN"] = bot
+        env["GIT_CONFIG_COUNT"] = "4"
+        env["GIT_CONFIG_KEY_0"] = "url.https://github.com/.insteadOf"
+        env["GIT_CONFIG_VALUE_0"] = "git@github.com:"
+        env["GIT_CONFIG_KEY_1"] = "url.https://github.com/.insteadOf"
+        env["GIT_CONFIG_VALUE_1"] = "ssh://git@github.com/"
+        env["GIT_CONFIG_KEY_2"] = "credential.https://github.com.helper"
+        env["GIT_CONFIG_VALUE_2"] = ""
+        env["GIT_CONFIG_KEY_3"] = "credential.https://github.com.helper"
+        env["GIT_CONFIG_VALUE_3"] = (
+            '!f() { test "$1" = get && '
+            'printf "username=x-access-token\\npassword=%s\\n" '
+            '"${GH_TOKEN:-${GITHUB_TOKEN:-${AOPS_BOT_GH_TOKEN}}}"; }; f'
+        )
+
+        # Force git to ignore user-config (HOME=tmp_path) so we test ONLY the
+        # GIT_CONFIG_KEY_* env layer — same layer the hook adds.
+        env["HOME"] = str(tmp_path)
+        env["XDG_CONFIG_HOME"] = str(tmp_path / "xdg")
+
+        result = subprocess.run(
+            ["git", "credential", "fill"],
+            env=env,
+            input="protocol=https\nhost=github.com\n\n",
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        out = result.stdout
+        assert "username=x-access-token" in out, (
+            f"Helper override must produce x-access-token username; got:\n{out}"
+        )
+        assert f"password={bot}" in out, "Helper override must produce bot PAT as password"

--- a/tests/integration/test_credential_isolation.py
+++ b/tests/integration/test_credential_isolation.py
@@ -623,15 +623,15 @@ class TestDeferredShellLines:
             "Must reference ${SOURCE} for value (defer to shell)"
         )
 
-    def test_shell_lines_emit_literals_directly(self):
-        """Literals are written as direct exports, not deferred references."""
+    def test_shell_lines_excludes_literals(self):
+        """Literals are excluded from shell_lines — they're written by set_persistent_env."""
         from lib.agent_env import get_env_mapping_shell_lines
 
         lines = get_env_mapping_shell_lines()
-        ssh_line = next((line for line in lines if "SSH_AUTH_SOCK" in line), None)
-        assert ssh_line is not None
-        # Literal empty value: `export SSH_AUTH_SOCK=''`
-        assert ssh_line.strip() == "export SSH_AUTH_SOCK=''"
+        # SSH_AUTH_SOCK is a literal entry; it must NOT appear in deferred lines.
+        assert not any("SSH_AUTH_SOCK" in line for line in lines), (
+            "Literal entries must be excluded from shell_lines to avoid redundant writes"
+        )
 
     def test_shell_lines_resolve_via_bash(self, credential_markers):
         """Bash-evaluating the shell lines must populate GH_TOKEN/GITHUB_TOKEN.


### PR DESCRIPTION
## Summary

Two changes addressing findings from session 305def0b (2026-04-29):

### 1. Credential isolation fix — Part B of task-0f7d3877

Closes a hole where agent operations were running under the user's
admin identity instead of the bot's Write-only role:

- **Root cause**: macOS Claude Desktop hook process inherits the
  launchd env (where `AOPS_BOT_GH_TOKEN` is unset) while the bash
  shell snapshot inherits `~/.zshenv` (where it IS set). The hook's
  Python-side env-to-env mapping silently skipped `GH_TOKEN`/
  `GITHUB_TOKEN`. With those empty, gh CLI fell through to the
  user's keyring auth (gho_\*), and git used `~/.gitconfig`'s
  host-specific `credential.https://github.com.helper = !gh auth
  git-credential` which shadowed the plugin's repo-local helper.
- **Fix**: write deferred shell-evaluated exports
  (`[ -n "${SOURCE+x}" ] && export TARGET="${SOURCE}"`) to
  `CLAUDE_ENV_FILE` so source resolution happens at shell-source
  time, plus inject `credential.https://github.com.helper` reset
  +install via `GIT_CONFIG_KEY_2/3` to defeat the precedence bug.
- **Tests**: 6 new tests verifying both pieces, including a real
  `git credential fill` invocation that returns the bot identity.

Net effect after this lands: `git push` and `gh` operations from
agent sessions authenticate as `botnicbot` (Write only), no admin
bypass.

### 2. /dump skill — tighter `release_summary` guidance

Real recent handovers like _"Root cause analysis completed.
Identified the failure as instruction-weighting + detection-failure
(enforcer had discretionary language and chose not to block;
orchestrator should have treated the flag as actionable). GitHub
issue filed."_ are unintelligible in a stack of unrelated handovers
on the dashboard. Added explicit guidance + before/after example
requiring named artifacts (which workflow, which incident, which
issue#) instead of role-only references. Also requires follow-up
task-IDs in the handover block to carry a parenthetical title.

## Test plan

- [x] `uv run pytest tests/hooks/ tests/integration/test_credential_isolation.py` — 527 passed
- [x] Manual: shell-lines bash subprocess test exercises the deferred resolution end-to-end
- [x] Manual: helper override test invokes real `git credential fill` and asserts the bot username/password

## Caveats

- Part A of task-0f7d3877 (locking the user's `~/.gitconfig` to
  1Password SSH only) is intentionally NOT in this PR. That is
  user-machine-specific config and lives in the dotfiles repo.
- The `~/.gitconfig` precedence hole is plugged at the
  GIT_CONFIG_KEY layer, which env-var-overrides any file-layer
  config — so this works even with the user's existing dotfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)