### PR TITLE
refactor(transcript): unify hook rendering across all event types

### DIFF
--- a/aops-core/lib/transcript_parser.py
+++ b/aops-core/lib/transcript_parser.py
@@ -3565,6 +3565,9 @@ class SessionProcessor:
         out = "> " + " — ".join(bits) + "\n"
 
         def _add_block(label: str, body: str, limit: int) -> str:
+            body = body.strip()
+            if not body:
+                return ""
             shown = body if full_mode or len(body) <= limit else body[:limit] + "..."
             quoted = _quote_block(_adjust_heading_levels(shown.strip(), 4))
             prefix = f"> _{label}:_\n" if label else ""

--- a/aops-core/lib/transcript_parser.py
+++ b/aops-core/lib/transcript_parser.py
@@ -3472,35 +3472,19 @@ class SessionProcessor:
             "early_reads": early_reads,
         }
 
-    # Hook events that get their own ``### Hook:`` header (session-level
-    # transitions worth flagging on their own line). Everything else is a
-    # tool-related event that we collapse to a one-line annotation when it
-    # carries useful payload, or skip when the verdict is the default.
-    _SESSION_LEVEL_HOOKS = frozenset(
-        {
-            "Stop",
-            "SessionStart",
-            "SessionEnd",
-            "UserPromptSubmit",
-            "Notification",
-            "PreCompact",
-        }
-    )
-
     @staticmethod
     def _render_hook(hook: dict, full_mode: bool) -> str:
-        """Render a single hook event compactly.
+        """Render a single hook event in unified format.
 
-        Tool-related hooks (PreToolUse, PostToolUse, SubagentStart/Stop)
-        collapse to a one-line ``> 🪝 …`` blockquote — and are suppressed
-        entirely when the verdict is the default ``allow`` and there's no
-        message or context-injection payload to surface, regardless of
-        ``full_mode``. The hook log is the source of truth for those; the
-        transcript is for human reading.
+        All hooks (PreToolUse, PostToolUse, Stop, Notification, etc.) share
+        one shape: a single ``> 🪝 …`` header line carrying every piece of
+        metadata (event, tool/agent, verdict, duration, skills, files,
+        +ctx), followed by blockquoted bodies for any multi-line payload —
+        system message, last-assistant tail (Stop), submitted prompt
+        (UserPromptSubmit), notification text, and injected context.
 
-        Session-level events (``Stop``, ``SessionStart`` etc.) keep an
-        ``### Hook:`` header and surface verdict, system message, and (for
-        ``Stop``) the last assistant message that triggered it.
+        No-op hooks (default ``allow`` verdict, no message, no payload) are
+        suppressed entirely — the hook log is the source of truth for those.
         """
         event_name = hook.get("hook_event_name") or "Hook"
         exit_code = hook.get("exit_code")
@@ -3520,140 +3504,95 @@ class SessionProcessor:
         is_blocking = hook_verdict in ("deny", "block", "request-changes")
         noteworthy_verdict = hook_verdict if hook_verdict and hook_verdict != "allow" else None
         is_error = exit_code is not None and exit_code != 0
-        is_session_level = event_name in SessionProcessor._SESSION_LEVEL_HOOKS
 
-        # Suppress noisy tool-related no-op hooks. The hook log keeps them;
-        # the transcript only shows the ones that DID something.
-        if not is_session_level:
-            has_payload = bool(
-                hook_system_message
-                or hook_context_injection
-                or skills_matched
-                or files_loaded
-                or noteworthy_verdict
-                or is_blocking
-                or is_error
-                or prevented
-            )
-            if not has_payload:
-                return ""
-
-        # Compact one-line form for tool-related hooks with payload.
-        if not is_session_level:
-            label = event_name
-            if tool_name:
-                label += f" {tool_name}"
-            elif agent_id:
-                label += f" (agent-{agent_id})"
-            verdict_part = ""
-            if is_blocking:
-                verdict_part = f" → 🛑 {hook_verdict}"
-            elif noteworthy_verdict:
-                verdict_part = f" → {noteworthy_verdict}"
-            elif is_error:
-                verdict_part = f" → exit {exit_code}"
-            msg_part = ""
-            if hook_system_message:
-                msg = hook_system_message.replace("\n", " ").strip()
-                if len(msg) > 120:
-                    msg = msg[:117] + "..."
-                msg_part = f" — {msg}"
-            extras: list[str] = []
-            if skills_matched:
-                extras.append("skills: " + ", ".join(f"`{s}`" for s in skills_matched))
-            if files_loaded:
-                extras.append(
-                    "loaded: " + ", ".join(f"`{fp.split('/')[-1]}`" for fp in files_loaded)
-                )
-            if hook_context_injection:
-                extras.append(f"+ctx {len(hook_context_injection):,}c")
-            extras_part = f" ({'; '.join(extras)})" if extras else ""
-            return f"> 🪝 {label}{verdict_part}{msg_part}{extras_part}\n\n"
-
-        # Session-level hook — full ### Hook: section with rich payload.
-        # The header line condenses event + checkmark + verdict + (intro to
-        # any system message) into one line; the message body, when present,
-        # follows as a fenced block.
-        checkmark = ""
-        if exit_code is not None:
-            checkmark = " ✓" if exit_code == 0 else f" ✗ (exit {exit_code})"
-        detail = ""
-        if tool_name:
-            detail = f": {tool_name}"
-        elif agent_id:
-            detail = f": agent-{agent_id}"
-
-        verdict_part = ""
-        if is_blocking:
-            verdict_part = f" — 🛑 denied verdict=`{hook_verdict}`"
-        elif noteworthy_verdict:
-            verdict_part = f" — verdict `{noteworthy_verdict}`"
-        elif event_name == "Stop":
-            verdict_part = " — verdict `allow`"
-
-        intro_part = " — ℹ️ Hook message:" if hook_system_message else ""
-        out = f"### Hook: {event_name}{detail}{checkmark}{verdict_part}{intro_part}\n\n"
-
-        if prevented:
-            out += "🛑 **Prevented continuation** — Stop hook blocked the agent from halting.\n\n"
-
-        if hook_system_message:
-            msg = hook_system_message
-            if not full_mode and len(msg) > 600:
-                msg = msg[:600] + "..."
-            out += f"```\n{msg}\n```\n\n"
-
-        # Stop: show the tail of the last assistant message that triggered
-        # this Stop event. Position alone (immediately under the Stop hook
-        # header) signals what the quoted block is; no label needed.
+        # Pull lifecycle-event payloads (prompt / notification text) up front so
+        # they count as "this hook did something" for suppression purposes.
+        prompt_text = ""
+        if event_name == "UserPromptSubmit" and isinstance(hook_raw_input, dict):
+            p = hook_raw_input.get("prompt")
+            if isinstance(p, str) and p.strip():
+                prompt_text = p.strip()
+        notification_text = ""
+        if event_name == "Notification" and isinstance(hook_raw_input, dict):
+            n = hook_raw_input.get("message")
+            if isinstance(n, str) and n.strip():
+                notification_text = n.strip()
+        last_assistant_tail = ""
         if event_name == "Stop" and isinstance(hook_raw_input, dict):
             last = hook_raw_input.get("last_assistant_message")
             if isinstance(last, str) and last.strip():
-                tail = last.strip()
-                if len(tail) > 240:
-                    tail = "…" + tail[-240:]
-                # Quote every line and demote any inner headings — the raw
-                # last-assistant message often contains markdown that would
-                # otherwise punch through the transcript's own structure.
-                quoted = _quote_block(_adjust_heading_levels(tail, 4))
-                out += f"{quoted}\n\n"
+                last_assistant_tail = last.strip()
 
-        # UserPromptSubmit: show the prompt itself in full mode.
-        if event_name == "UserPromptSubmit" and full_mode and isinstance(hook_raw_input, dict):
-            prompt = hook_raw_input.get("prompt")
-            if isinstance(prompt, str) and prompt.strip():
-                preview = prompt.strip()
-                if len(preview) > 300:
-                    preview = preview[:300] + "..."
-                out += f"_Prompt:_ {preview}\n\n"
+        has_payload = bool(
+            hook_system_message
+            or hook_context_injection
+            or skills_matched
+            or files_loaded
+            or noteworthy_verdict
+            or is_blocking
+            or is_error
+            or prevented
+            or prompt_text
+            or notification_text
+            or last_assistant_tail
+            or content
+        )
+        if not has_payload:
+            return ""
 
-        # Notification: show the notification text (e.g. idle prompt).
-        if event_name == "Notification" and isinstance(hook_raw_input, dict):
-            note = hook_raw_input.get("message")
-            if isinstance(note, str) and note.strip():
-                out += f"_Notification:_ {note.strip()}\n\n"
-
+        # One-line metadata header.
+        bits: list[str] = [f"🪝 {event_name}"]
+        if tool_name:
+            bits.append(f"`{tool_name}`")
+        elif agent_id:
+            bits.append(f"agent-{agent_id}")
+        if is_blocking:
+            bits.append(f"🛑 `{hook_verdict}`")
+        elif noteworthy_verdict:
+            bits.append(f"verdict `{noteworthy_verdict}`")
+        elif is_error:
+            bits.append(f"exit {exit_code}")
+        if prevented:
+            bits.append("🛑 prevented-continuation")
         if duration_ms:
-            out += f"_Hook ran in {duration_ms}ms._\n\n"
-
+            bits.append(f"{duration_ms}ms")
         if skills_matched:
-            out += "Skills matched: " + ", ".join(f"`{s}`" for s in skills_matched) + "\n\n"
+            bits.append("skills: " + ", ".join(f"`{s}`" for s in skills_matched))
         if files_loaded:
-            files_str = ", ".join(f"`{fp.split('/')[-1]}`" for fp in files_loaded)
-            out += f"Loaded {files_str} (content injected)\n\n"
+            bits.append("loaded: " + ", ".join(f"`{fp.split('/')[-1]}`" for fp in files_loaded))
+        if hook_context_injection:
+            bits.append(f"+ctx {len(hook_context_injection):,}c")
+        out = "> " + " — ".join(bits) + "\n"
+
+        def _add_block(label: str, body: str, limit: int) -> str:
+            shown = body if full_mode or len(body) <= limit else body[:limit] + "..."
+            quoted = _quote_block(_adjust_heading_levels(shown.strip(), 4))
+            prefix = f"> _{label}:_\n" if label else ""
+            return f">\n{prefix}{quoted}\n"
+
         if tool_input and tool_name:
             tool_summary = _summarize_tool_input(tool_name, tool_input)
             if tool_summary:
-                out += f"**{tool_name}**: `{tool_summary}`\n\n"
+                out += f"> **{tool_name}**: `{tool_summary}`\n"
+        if prompt_text and full_mode:
+            out += _add_block("prompt", prompt_text, 300)
+        if notification_text:
+            out += _add_block("notification", notification_text, 300)
+        if hook_system_message:
+            out += _add_block("", hook_system_message.strip(), 600)
+        if last_assistant_tail:
+            tail = last_assistant_tail
+            if len(tail) > 240:
+                tail = "…" + tail[-240:]
+            out += _add_block("triggered after", tail, len(tail))
         if content:
-            shown = content if full_mode or len(content) <= 300 else content[:300] + "..."
-            out += f"```\n{shown}\n```\n\n"
+            out += _add_block("", content, 300)
         if hook_context_injection:
             inj = hook_context_injection
-            preview = inj if full_mode and len(inj) <= 1200 else inj[:300] + "..."
-            out += f"_Injected context ({len(inj):,} chars):_\n\n```\n{preview}\n```\n\n"
+            limit = 1200 if full_mode else 300
+            out += _add_block(f"injected context ({len(inj):,} chars)", inj, limit)
 
-        return out
+        return out + "\n"
 
     @staticmethod
     def _keep_hook(h: dict) -> bool:

--- a/tests/lib/test_session_context_section.py
+++ b/tests/lib/test_session_context_section.py
@@ -136,8 +136,9 @@ def _extract_section(md: str, heading: str = "## Session Context") -> str:
 
     The Session Context section ends at:
       - the next top-level ``## `` heading, OR
-      - the first per-turn ``### Hook:`` header (new compact rendering), OR
-      - the first legacy ``- Hook(`` bullet (old rendering, kept for safety).
+      - the first per-turn ``> 🪝`` header (unified compact rendering), OR
+      - the first legacy ``### Hook:`` header (old rendering, kept for safety), OR
+      - the first legacy ``- Hook(`` bullet (older rendering, kept for safety).
     """
     if heading not in md:
         return ""
@@ -147,9 +148,12 @@ def _extract_section(md: str, heading: str = "## Session Context") -> str:
     next_h2 = rest.find("\n## ")
     if next_h2 != -1:
         candidates.append(next_h2)
-    per_turn_hook = rest.find("\n### Hook:")
+    per_turn_hook = rest.find("\n> 🪝")
     if per_turn_hook != -1:
         candidates.append(per_turn_hook)
+    legacy_hook_h3 = rest.find("\n### Hook:")
+    if legacy_hook_h3 != -1:
+        candidates.append(legacy_hook_h3)
     legacy_hook = rest.find("\n- Hook(")
     if legacy_hook != -1:
         candidates.append(legacy_hook)

--- a/tests/lib/test_token_tracking.py
+++ b/tests/lib/test_token_tracking.py
@@ -625,10 +625,11 @@ class TestPerToolResultTokens:
 
 class TestCondensedHookHeader:
     """The session-level Hook header collapses event + checkmark + verdict
-    + (intro to any system message) into a single line. The body of the
-    system message follows as a fenced block; the verdose intermediary
-    lines (`**Verdict:** \\`x\\``, `ℹ️ Hook message:`) are removed, as is
-    the `_Triggered after assistant message:_` literal under Stop hooks.
+    + duration + skills/files/+ctx into a single line. The body of any
+    system message follows as a blockquote; the verbose intermediary
+    lines (`**Verdict:** \\`x\\``, `ℹ️ Hook message:`, `_Hook ran in Xms._`)
+    are removed, as is the `_Triggered after assistant message:_` literal
+    under Stop hooks.
     """
 
     def test_stop_with_warn_verdict_and_message_collapses_to_one_line(self, tmp_path):
@@ -659,20 +660,16 @@ class TestCondensedHookHeader:
             session, entries, agent_entries=None, variant="full"
         )
 
-        # Single-line condensed header: event + checkmark + verdict + intro.
-        assert "### Hook: Stop ✓ — verdict `warn` — ℹ️ Hook message:" in markdown
-        # Removed: the standalone `**Verdict:** ...` line that used to follow
-        # the heading. (The string matches must be on its own line — i.e.
-        # surrounded by newlines — to distinguish from the inline form.)
+        # Unified one-line header: event + verdict (no checkmark on this form).
+        assert "> 🪝 Stop — verdict `warn`" in markdown
+        # No standalone `**Verdict:** ...` line.
         assert "\n**Verdict:** `warn`\n" not in markdown
-        # Removed: the standalone `ℹ️ Hook message:` paragraph above the
-        # fenced body (still allowed as a tail of the condensed header).
-        assert "\n\nℹ️ Hook message:\n\n```" not in markdown
-        # Removed the "Triggered after" literal — quoted block stands alone.
-        assert "_Triggered after assistant message:_" not in markdown
-        # The body still appears.
-        assert "Halted — review pending." in markdown
-        assert "I'm stopping here." in markdown
+        # No "ℹ️ Hook message:" intro and no fenced code body.
+        assert "ℹ️ Hook message" not in markdown
+        assert "```\nHalted" not in markdown
+        # The body still appears, as a blockquote.
+        assert "> Halted — review pending." in markdown
+        assert "> I'm stopping here." in markdown
 
     def test_stop_with_no_message_only_header_line(self, tmp_path):
         import json
@@ -696,6 +693,7 @@ class TestCondensedHookHeader:
         markdown = processor.format_session_as_markdown(
             session, entries, agent_entries=None, variant="full"
         )
-        # Default Stop verdict surfaces as `allow`, no intro since no message.
-        assert "### Hook: Stop ✓ — verdict `allow`" in markdown
+        # Default `allow` verdict with no message/payload is suppressed
+        # entirely — the hook log is the source of truth for no-op hooks.
+        assert "🪝 Stop" not in markdown
         assert "Hook message" not in markdown


### PR DESCRIPTION
## Summary

- All hooks (PreToolUse, Stop, Notification, UserPromptSubmit, etc.) now share one rendering shape: a single `> 🪝 …` blockquote header carrying every metadata field on one line, followed by labelled blockquoted bodies for any multi-line payload.
- Drops the session-level / tool-level distinction in `_render_hook` — a hook is a hook. Removes the `### Hook:` heading, the standalone `**Verdict:**` line, the `ℹ️ Hook message:` intro, the `_Hook ran in Xms._` footer, and the fenced code blocks that punched through transcript structure.
- No-op hooks (default `allow`, no payload) remain suppressed.

## Test plan

- [x] `tests/lib/test_transcript_hook_output.py` (4 tests)
- [x] `tests/lib/test_token_tracking.py` `TestCondensedHookHeader` (updated to expect `> 🪝 Stop — verdict ...` format and suppression of no-op `allow` hooks)
- [x] `tests/lib/test_session_context_section.py` (updated `_extract_section` to recognise new `> 🪝` boundary marker)
- [x] `tests/lib/test_transcript_parser_reflection.py`
- [x] All 76 tests in the affected suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)