### PR TITLE
fix(ci): eliminate merge-prep concurrency waste

### DIFF
--- a/.github/workflows/agent-merge-prep.yml
+++ b/.github/workflows/agent-merge-prep.yml
@@ -52,20 +52,22 @@ on:
         description: 'OAuth token for Claude agent'
         required: true
 
-# Global concurrency: serialise merge-prep across all PRs to prevent API rate limits
-concurrency:
-  group: merge-prep-global
-  cancel-in-progress: false
+# No global concurrency group. GitHub's concurrency model only keeps 1 running +
+# 1 pending per group — dispatching N runs into one group discards N-2 immediately.
+# Serialisation happens at the dispatcher level (one PR per tick) instead.
 
 jobs:
   fix:
     timeout-minutes: 45
     name: Merge Prep
     runs-on: ubuntu-latest
-    # Per-PR concurrency prevents duplicate runs on the same PR across cron ticks
+    # Per-PR concurrency prevents duplicate runs on the same PR across cron ticks.
+    # cancel-in-progress: false — let a running prep finish rather than killing it
+    # and restarting. The dispatcher's active-check prevents dispatching duplicates;
+    # this is the safety net if one slips through.
     concurrency:
       group: merge-prep-${{ inputs.pr_number }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/merge-prep-cron.yml
+++ b/.github/workflows/merge-prep-cron.yml
@@ -62,7 +62,7 @@ on:
 
 concurrency:
   group: merge-prep-dispatcher
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   dispatch:
@@ -245,7 +245,7 @@ jobs:
             echo "$PR_NUM|$HEAD_REF" >> /tmp/qualifying_prs.txt
           done
 
-      - name: Dispatch merge-prep for qualifying PRs
+      - name: Dispatch merge-prep for oldest qualifying PR
         if: inputs.pr_number == '' && steps.pr-count.outputs.skip != 'true' && steps.active-check.outputs.skip_all != 'true'
         run: |
           REPO="${{ github.repository }}"
@@ -255,14 +255,19 @@ jobs:
             exit 0
           fi
 
-          while IFS='|' read -r PR_NUM HEAD_REF; do
-            echo "Dispatching merge-prep for PR #$PR_NUM (branch: $HEAD_REF)"
+          # Dispatch ONE PR per tick. GitHub's concurrency model only keeps
+          # 1 running + 1 pending per group — dispatching N runs discards N-2.
+          # The cron (30 min) and workflow_run triggers ensure the next PR gets
+          # picked up after the current one finishes.
+          IFS='|' read -r PR_NUM HEAD_REF < /tmp/qualifying_prs.txt
 
-            gh workflow run "$WORKFLOW_REF" \
-              --repo "$REPO" \
-              --ref "refs/heads/$HEAD_REF" \
-              -f pr_number="$PR_NUM" \
-              -f bot_identity="$BOT_IDENTITY"
+          TOTAL=$(wc -l < /tmp/qualifying_prs.txt | tr -d ' ')
+          echo "Dispatching merge-prep for PR #$PR_NUM (1 of $TOTAL qualifying)"
 
-            echo "  Dispatched successfully"
-          done < /tmp/qualifying_prs.txt
+          gh workflow run "$WORKFLOW_REF" \
+            --repo "$REPO" \
+            --ref "refs/heads/$HEAD_REF" \
+            -f pr_number="$PR_NUM" \
+            -f bot_identity="$BOT_IDENTITY"
+
+          echo "  Dispatched successfully. Remaining $((TOTAL - 1)) PRs will be picked up on subsequent ticks."


### PR DESCRIPTION
## Summary

- Remove global `merge-prep-global` concurrency group from agent workflow — GitHub only keeps 1 running + 1 pending per group, so dispatching N runs silently discards N-2
- Change per-PR concurrency from `cancel-in-progress: true` to `false` — let running preps finish instead of killing and restarting on re-dispatch
- Dispatcher now dispatches one qualifying PR per tick instead of all — the rest were getting discarded by the concurrency gate anyway; cron + workflow_run triggers pick up subsequent PRs

## Problem

When 17 PRs landed from the overnight polecat wave, the merge prep pipeline showed: 8 agent runs dispatched at the same second, 7 immediately cancelled. Only 1 survived per dispatch cycle. Runs that had been working for 8+ minutes were killed and restarted, wasting all progress.

Root cause: GitHub's `cancel-in-progress: false` concurrency model keeps exactly **1 running + 1 pending** — each new pending run replaces the previous one. Combined with `cancel-in-progress: true` on the per-PR group, every re-dispatch cycle killed in-progress work.

## Test plan

- [ ] Verify merge-prep dispatches one PR at a time (check GHA run list after next cron tick with multiple qualifying PRs)
- [ ] Verify no cascading cancellations when multiple PRs qualify simultaneously
- [ ] Verify a running prep is not killed when the dispatcher fires again for the same PR

Closes task-ef0b83a0

🤖 Generated with [Claude Code](https://claude.com/claude-code)