### PR TITLE
supervisor: dispatch primitive is polecat run, supervisor is the smart layer

### DIFF
--- a/aops-core/skills/supervisor/SKILL.md
+++ b/aops-core/skills/supervisor/SKILL.md
@@ -156,6 +156,28 @@ The supervisor never silently substitutes a different **worker type**, **deliver
 
 In autonomous (loop) sessions, legitimate halts set the epic to `blocked` or `review`; the next interactive supervisor invocation picks it up.
 
+### The Dispatch Primitive Is `polecat run` — The Supervisor Is The Smart Layer
+
+Dispatch policy — _when_ to fire the next worker, _whether_ to pair two in flight, when to back off, when to halt — is **supervisor judgment**. It does not belong in a CLI flag, a shell wrapper, or a batched "swarm" abstraction. The primitive is one line:
+
+```bash
+ssh TARGET_HOST "zsh -i -c 'polecat run -t <task-id> -p <project>' [--gemini]"
+```
+
+(Drop the SSH wrapper when supervisor and polecat host are the same machine. `DOCKER_HOST=ssh://wsl` is **not** a clean alternative — `polecat run` does local FS work for worktrees, `.polecat` state, and PKB socket reachability, so the docker daemon must live on the same host as polecat.)
+
+That contract — one agent, one task, exit code is the verdict, PR in `gh pr list`, PKB status flips — is the whole interface. The supervisor does not need a structured events stream, run-id-namespaced logs, or quota-aware backoff features _in polecat_ to operate. Those needs only emerge if the supervisor tries to fan out 30+ workers and parse stream telemetry; at sequential N=2–4 (the regime [[#halt-on-substitute]] and [Reporting Posture](#reporting-posture) actually support), exit codes plus `gh pr list` plus PKB status are sufficient.
+
+**Forbidden dispatch shapes** (file via `/learn` if any appear in a supervisor transcript):
+
+- Building `~/bin/polecat-*.sh` or any wrapper that "manages" `polecat run` invocations.
+- Using `polecat swarm` as the primary dispatch path. The subcommand exists, but it externalises judgment the supervisor should be making per-dispatch. Reach for it only on explicit user direction for a known-uniform batch.
+- Filing "polecat needs feature X for adaptive supervision" without first asking: do I actually need this at N=2–4 sequential?
+
+**When a correction lands** ("stop building wrappers"), the lesson is **not** "encode the same policy into a different tool." The lesson is: this judgment lives in the supervisor loop. Do it in supervisor judgment, in bash, one call at a time, with PKB writes between.
+
+If pacing-the-pipe ever genuinely needs more than the supervisor + `polecat run` + PKB + `gh pr list`, that is a SKILL.md change to discuss with the user — not a polecat feature request and not a wrapper.
+
 ### Engineering Integrity (A8) Is Non-Negotiable
 
 Failing tests, broken tools, and incompatible environments are bugs the supervisor's plan must fix — never categories the supervisor's plan triages around. The verbatim list of prohibited prose patterns (drift candidate, skip-on-env, "fix vs skip", etc.) is canonical at [[instructions/decomposition-and-review#a8-prose-scan-mandatory-before-posting-any-decomposition]] and is enforced by pauli during preflight and decomposition. Casual user phrasing such as "we may need to adjust some tests" does NOT authorise A8 exemption — A8 is universal (per A7) and only an explicit user directive to skip a specific test counts.

--- a/aops-core/skills/supervisor/SKILL.md
+++ b/aops-core/skills/supervisor/SKILL.md
@@ -156,27 +156,11 @@ The supervisor never silently substitutes a different **worker type**, **deliver
 
 In autonomous (loop) sessions, legitimate halts set the epic to `blocked` or `review`; the next interactive supervisor invocation picks it up.
 
-### The Dispatch Primitive Is `polecat run` — The Supervisor Is The Smart Layer
+### Dispatch Is Supervisor Judgment — Not A Wrapper Or A Swarm
 
-Dispatch policy — _when_ to fire the next worker, _whether_ to pair two in flight, when to back off, when to halt — is **supervisor judgment**. It does not belong in a CLI flag, a shell wrapper, or a batched "swarm" abstraction. The primitive is one line:
+Dispatch policy — _when_ to fire the next worker, _whether_ to pair two in flight, when to back off, when to halt — is **supervisor judgment**. It does not belong in a CLI flag, a shell wrapper (`~/bin/polecat-*.sh`), or a batched "swarm" abstraction. The dispatch CLI is documented at [[instructions/worker-dispatch#dispatch-protocol]] — exit code, `gh pr list`, and PKB status are the whole telemetry surface at the sequential N=2–4 regime [Reporting Posture](#reporting-posture) actually supports.
 
-```bash
-ssh TARGET_HOST "zsh -i -c 'polecat run -t <task-id> -p <project> [--gemini]'"
-```
-
-(Drop the SSH wrapper when supervisor and polecat host are the same machine. `DOCKER_HOST=ssh://wsl` is **not** a clean alternative — `polecat run` does local FS work for worktrees, `.polecat` state, and PKB socket reachability, so the docker daemon must live on the same host as polecat.)
-
-That contract — one agent, one task, exit code is the verdict, PR in `gh pr list`, PKB status flips — is the whole interface. The supervisor does not need a structured events stream, run-id-namespaced logs, or quota-aware backoff features _in polecat_ to operate. Those needs only emerge if the supervisor tries to fan out 30+ workers and parse stream telemetry; at sequential N=2–4 (the regime [[#halt-on-substitute]] and [Reporting Posture](#reporting-posture) actually support), exit codes plus `gh pr list` plus PKB status are sufficient.
-
-**Forbidden dispatch shapes** (file via `/learn` if any appear in a supervisor transcript):
-
-- Building `~/bin/polecat-*.sh` or any wrapper that "manages" `polecat run` invocations.
-- Using `polecat swarm` as the primary dispatch path. The subcommand exists, but it externalises judgment the supervisor should be making per-dispatch. Reach for it only on explicit user direction for a known-uniform batch.
-- Filing "polecat needs feature X for adaptive supervision" without first asking: do I actually need this at N=2–4 sequential?
-
-**When a correction lands** ("stop building wrappers"), the lesson is **not** "encode the same policy into a different tool." The lesson is: this judgment lives in the supervisor loop. Do it in supervisor judgment, in bash, one call at a time, with PKB writes between.
-
-If pacing-the-pipe ever genuinely needs more than the supervisor + `polecat run` + PKB + `gh pr list`, that is a SKILL.md change to discuss with the user — not a polecat feature request and not a wrapper.
+**When a correction lands** ("stop building wrappers"), the lesson is **not** "encode the same policy into a different tool." The lesson is: this judgment lives in the supervisor loop. Do it in supervisor judgment, in bash, one call at a time, with PKB writes between. If pacing-the-pipe ever genuinely needs more, that is a SKILL.md change to discuss with the user — not a polecat feature request and not a wrapper.
 
 ### Engineering Integrity (A8) Is Non-Negotiable
 

--- a/aops-core/skills/supervisor/SKILL.md
+++ b/aops-core/skills/supervisor/SKILL.md
@@ -161,7 +161,7 @@ In autonomous (loop) sessions, legitimate halts set the epic to `blocked` or `re
 Dispatch policy — _when_ to fire the next worker, _whether_ to pair two in flight, when to back off, when to halt — is **supervisor judgment**. It does not belong in a CLI flag, a shell wrapper, or a batched "swarm" abstraction. The primitive is one line:
 
 ```bash
-ssh TARGET_HOST "zsh -i -c 'polecat run -t <task-id> -p <project>' [--gemini]"
+ssh TARGET_HOST "zsh -i -c 'polecat run -t <task-id> -p <project> [--gemini]'"
 ```
 
 (Drop the SSH wrapper when supervisor and polecat host are the same machine. `DOCKER_HOST=ssh://wsl` is **not** a clean alternative — `polecat run` does local FS work for worktrees, `.polecat` state, and PKB socket reachability, so the docker daemon must live on the same host as polecat.)


### PR DESCRIPTION
## Summary

- Adds new SKILL.md design principle: "The Dispatch Primitive Is \`polecat run\` — The Supervisor Is The Smart Layer"
- Names three forbidden dispatch shapes (wrappers, swarm-as-primary, polecat feature requests that only matter at fanout >20)
- Companion PKB cancellations: aops-924ae91f, aops-01def340, aops-6177e24f (over-built telemetry tasks)

## Context

Retro on session [6956bd3c](https://github.com/nicsuzor/brain) — supervisor built \`~/bin/polecat-swarm.sh\` wrapper, then on correction pivoted to "build the missing features into \`polecat swarm\`". Both are the same anti-pattern: externalising supervisor judgment into static infrastructure.

User direction (2026-05-13): "What I want is a smart supervisor that can execute dispatch commands and use its judgment."

\`polecat run\` is the primitive. SSH wraps the command. The supervisor reads the exit code, \`gh pr list\`, and PKB status — that's the whole telemetry surface at sequential N=2–4.

\`DOCKER_HOST=ssh://wsl\` tested and rejected as remote-dispatch alternative — polecat needs local FS (worktrees, \`.polecat\` state, PKB socket reachability), so the docker daemon must live on the polecat host. SSH-the-command stays the answer.

## Test plan

- [ ] Next supervisor dogfood session uses one \`polecat run\` at a time
- [ ] No wrapper scripts created
- [ ] No new polecat feature requests filed for telemetry the supervisor doesn't need at N=2–4

## Cost-Benefit Analysis

> Required by [ENFORCEMENT-MAP.md §"PR requirements for enforcement changes"](/.agents/ENFORCEMENT-MAP.md) for skill instruction changes targeting agent behaviour.

### 1. Friction evidence (≥3 recurrences)

- **Recurrence A** — Session [6956bd3c](https://github.com/nicsuzor/brain) (2026-05-13): supervisor built `~/bin/polecat-swarm.sh`, externalising dispatch judgment into a static shell wrapper.
- **Recurrence B** — Same session, after correction: supervisor pivoted to filing polecat-swarm feature requests (`aops-924ae91f`, `aops-01def340`, `aops-6177e24f`) for adaptive ramp / namespaced logs / quota-aware backoff. Three PKB tasks, each documenting a distinct instance of the "move judgment into the dispatcher" anti-pattern. All three subsequently cancelled.
- **Recurrence C** — PR #991 review feedback (`worker-dispatch.md:218,229,236`): the supervisor skill's own prior documentation promoted `polecat swarm` as the multi-task dispatch primitive. User direction: deprecate. Same anti-pattern at the documentation layer.

### 2. Cheapest plausible level

**L1** (SKILL.md text). The miss is a behavioural disposition (where the smarts live: dispatcher vs supervisor), correctable by adding ~10 lines of design principle to the relevant skill.

### 3. Why this level (not escalation)?

No gate or axiom is needed. Halt-on-substitute (A-tier) already covers cross-context substitution. This section names the dispatch shape specifically and points at the canonical CLI doc rather than duplicating it.

### 4. Ongoing cost

- **Mechanism level**: L1 (SKILL.md text, prompt-cached at SessionStart).
- **Marginal cost per session**: ~50–150 tok (the trimmed section is ~8 lines, cached).
- **Fire frequency**: every supervisor invocation — roughly 5–15 sessions/day.
- **Per-day estimate**: 250–2,250 tok/day. Low end of L1 band.

### 5. Reversibility

**Acceptance criterion**: zero wrapper-creation or "polecat needs feature X for adaptive supervision" incidents in the next 5 /retro reviews of supervisor sessions after merge.

**Rollback path**: trivial — revert this commit and the SKILL.md returns to its prior state.
