### PR TITLE
chore(supervisor): surface RBG axiom-check in Decompose phase

### DIFF
--- a/aops-core/skills/supervisor/SKILL.md
+++ b/aops-core/skills/supervisor/SKILL.md
@@ -223,15 +223,15 @@ Before asserting "I can't dispatch worker X" or "I don't have access to repo Y",
 
 The supervisor is a loop, not a pipeline. Each tick enters one phase and exits.
 
-| Phase     | Subagent | What happens                                                                                 |
-| --------- | -------- | -------------------------------------------------------------------------------------------- |
-| Orient    | (none)   | Main agent reads epic body; runs brake; chooses subagent role                                |
-| Decompose | pauli    | Pauli proposes subtasks. See [[instructions/decomposition-and-review]]                       |
-| Review    | (none)   | Plan-review halt — decomposition synthesised; awaits human promotion to `queued`             |
-| Dispatch  | pauli    | Pauli recommends dispatch; main agent runs the command. See [[instructions/worker-dispatch]] |
-| Verify    | marsha   | Marsha returns PASS/FAIL/REVISE on a worker exit                                             |
-| React     | pauli    | Pauli recommends a fix-task or a halt after a FAIL                                           |
-| Halt      | (none)   | All work items at review surface or escalated; emit final summary; exit                      |
+| Phase     | Subagent | What happens                                                                                                                                                              |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Orient    | (none)   | Main agent reads epic body; runs brake; chooses subagent role                                                                                                             |
+| Decompose | pauli    | Pauli proposes subtasks; RBG axiom-check runs in parallel as a mandatory reviewer (verdict: OK/WARN/BLOCK gates promotion). See [[instructions/decomposition-and-review]] |
+| Review    | (none)   | Plan-review halt — decomposition synthesised; awaits human promotion to `queued`                                                                                          |
+| Dispatch  | pauli    | Pauli recommends dispatch; main agent runs the command. See [[instructions/worker-dispatch]]                                                                              |
+| Verify    | marsha   | Marsha returns PASS/FAIL/REVISE on a worker exit                                                                                                                          |
+| React     | pauli    | Pauli recommends a fix-task or a halt after a FAIL                                                                                                                        |
+| Halt      | (none)   | All work items at review surface or escalated; emit final summary; exit                                                                                                   |
 
 `Review` and `Halt` are real terminal states, not transient phases. The supervisor never finalises the deliverable itself — it hands off at the review surface. Async ownership transfers to whatever review pipeline the deliverable subworkflow defines.
 


### PR DESCRIPTION
## Summary

Task aops-3372fd48 — wire supervisor-side RBG axiom-check trigger, matching the planner pattern from PR #990.

RBG is already invoked as a parallel reviewer during Phase 2 of supervisor decomposition (see `instructions/decomposition-and-review.md` lines 187, 197-203, 242). This one-line edit to the Phases table in `SKILL.md` surfaces that fact at the top-level skill view, so readers don't have to follow the instruction link to learn that axiom checks gate promotion.

No new infrastructure — RBG verdict (OK/WARN/BLOCK) and the synthesis/halt gate were already wired.

## Test plan

- [ ] Verify Decompose row in Phases table mentions RBG axiom-check
- [ ] Confirm `instructions/decomposition-and-review.md` RBG invocation is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)