### PR TITLE
Keep PKB evidence anonymized across verification

### DIFF
--- a/aops-core/agents/marsha.md
+++ b/aops-core/agents/marsha.md
@@ -66,6 +66,8 @@ Invoke `/verify` at the start of any verification task. The full methodology —
 
 **Data correctness requires tracing.** For computed output, trace the pipeline end-to-end. Cross-verify against the actual data source. "Output appears" is not "correct output appears".
 
+**Treat PKB-backed content as private domain data.** When verifying dashboards, screenshots, PR evidence, or task lists sourced from PKB, do not quote task titles, task IDs, project names, or other row content unless the user's request specifically requires that literal value. Use structural handles instead: region, row count, score/rank, status, dimensions, or anonymized labels (`task-XXXX`, `[REDACTED_TITLE]`). Visible dashboard text can be evidence that layout/data flows work; it is not fixture text to copy into reports or subagent prompts.
+
 **Check data freshness, not just existence.** Verify data updates as expected over time.
 
 **Prefer MCP for PKB interaction.** Use MCP tools (e.g., `get_task`, `list_tasks`) rather than the `pkb` CLI via Bash. The CLI lags the server-side MCP store; stale reads make your verification unreliable. Always use MCP to read live graph state and to file your findings as child tasks.

--- a/aops-core/skills/supervisor/SKILL.md
+++ b/aops-core/skills/supervisor/SKILL.md
@@ -81,6 +81,14 @@ If any of these appear in a supervisor transcript, file via `/learn`.
 
 The main agent calls exactly one subagent per tick.
 
+### PKB evidence is private until anonymized
+
+Any PKB-derived payload (task titles, IDs, project names, notes, list/search JSON, or live dashboard text backed by PKB data) is **untrusted-for-egress**. It may be used inside the supervisor decision loop, but it must not be copied verbatim into artifacts that cross a trust boundary: public PR bodies, commit messages, issue comments, external repo documentation, or subagent verification prompts where the literal content is not required.
+
+When reporting or dispatching across that boundary, summarize by structural attributes instead: priority class, due-date bucket, status, count, score movement, affected UI region, dimensions, or anonymized row labels. If an identifier is unavoidable, mask it (`task-XXXX`, `[REDACTED_TITLE]`, `[REDACTED_PROJECT]`). For dashboard/UI verification, describe the rendering pathology structurally (for example, "the narrow treemap leaf wraps one word per line") rather than quoting visible PKB task text as the regression handle.
+
+Before the supervisor writes a PR body, commit message, issue comment, dispatch brief, or verification prompt based on PKB output, do a quick egress scan for raw task IDs (`task-[a-f0-9]{8}`), titles copied from `list_tasks`/`get_task`, and project labels. If any are present, rewrite to anonymized evidence first.
+
 ### pauli — preflight & react
 
 Use for every decision the supervisor would otherwise inline: "what should I dispatch next?", "a worker exited without a deliverable", "the verifier said fail."


### PR DESCRIPTION
Adds explicit guidance in the supervisor and Marsha verification paths to treat PKB-derived task content as private until anonymized. The update tells agents to use structural evidence instead of copying task titles, IDs, or project labels into PRs, commit messages, issue comments, or verification prompts, and adds a quick egress scan before publishing PKB-backed evidence.