### PR TITLE
feat(project): provision canonical label set on repo init

### DIFF
--- a/aops-core/skills/project/instructions/init.md
+++ b/aops-core/skills/project/instructions/init.md
@@ -411,6 +411,44 @@ body:
       required: true
 ```
 
+### Canonical labels
+
+Provision the framework's canonical label set on the new repo. Issue templates and the `repo-sync-cron` triage pipeline assume these exist — GitHub does **not** auto-create labels from `labels:` fields in issue templates, and `gh pr edit --add-label` against a missing label fails with exit 1 (which historically caused `pr-state.json` to bail mid-write; see aops-2a4d0d47).
+
+`gh label create --force` is idempotent — safe to re-run on existing repos.
+
+```bash
+# Issue-template defaults (referenced by .github/ISSUE_TEMPLATE/*.yml)
+gh label create task        --color "0e8a16" --description "Discrete unit of work"               --force
+gh label create bug         --color "d73a4a" --description "Defect or regression"                --force
+gh label create enhancement --color "a2eeef" --description "Improvement to existing capability"  --force
+gh label create triage      --color "fbca04" --description "Needs initial triage"                --force
+
+# PR triage routing (consumed by aops-core/scripts/dump_pr_state.py)
+gh label create "triage:escalate"       --color "b60205" --description "PR needs human attention (CI failed / stalled)" --force
+gh label create "triage:stale"          --color "cccccc" --description "Open >7d without merge or update"               --force
+gh label create "triage:auto-mergeable" --color "0e8a16" --description "Bot-authored, CI green, safe to auto-merge"     --force
+gh label create "triage:needs-judgment" --color "fbca04" --description "Human-authored, needs review judgment"          --force
+
+# Issue-sweep dispositions (consumed by aops-core/skills/survey, sweep mode)
+gh label create "triaged-stale"   --color "ededed" --description "Sweep: closed as stale"            --force
+gh label create "triaged-comment" --color "ededed" --description "Sweep: merged into canonical"     --force
+gh label create "triaged-single"  --color "ededed" --description "Sweep: filed as single polecat task" --force
+gh label create "triaged-epic"    --color "ededed" --description "Sweep: filed as fix-epic"         --force
+gh label create "triaged-defer"   --color "ededed" --description "Sweep: deferred; revisit-by date set" --force
+
+# Criticality (used by survey + sweep when filing/triaging issues)
+gh label create "criticality:critical" --color "b60205" --description "Production-blocking or data-integrity risk" --force
+gh label create "criticality:high"     --color "d93f0b" --description "Material impact on workflows"               --force
+gh label create "criticality:medium"   --color "fbca04" --description "Noticeable but contained"                   --force
+gh label create "criticality:low"      --color "0e8a16" --description "Polish, minor friction"                     --force
+
+# PR origin
+gh label create polecat --color "5319e7" --description "PR authored by a polecat worker" --force
+```
+
+If the cron's `gh` token lacks `repo:write` on the new repo, label provisioning will fail loudly here rather than silently downstream — file a token-scope task and HALT per the fail-fast rule.
+
 ## Step 5: Research tooling (conditional)
 
 Only create these if the user selected them in Phase 1.


### PR DESCRIPTION
## Summary
- Adds a "Canonical labels" subsection to Step 4 of `aops-core/skills/project/instructions/init.md`.
- Provisions the full framework label set (issue-template defaults, PR triage routing, sweep dispositions, criticality, polecat) via idempotent `gh label create --force`.
- Closes the gap surfaced as `aops-2a4d0d47` and tracked as `aops-4379678c`: `triage:*` labels were never provisioned anywhere, so `dump_pr_state.py` was calling `gh pr edit --add-label` against labels that didn't exist → exit 1 → cron bailed mid-write.

Companion fix: [#1052](https://github.com/nicsuzor/academicOps/pull/1052) hardens the cron against the failure; this PR fixes the underlying provisioning gap.

## Labels added
- Issue-template defaults: \`task\`, \`bug\`, \`enhancement\`, \`triage\`
- PR triage routing: \`triage:escalate\`, \`triage:stale\`, \`triage:auto-mergeable\`, \`triage:needs-judgment\`
- Sweep dispositions: \`triaged-stale\`, \`triaged-comment\`, \`triaged-single\`, \`triaged-epic\`, \`triaged-defer\`
- Criticality: \`criticality:critical\`, \`criticality:high\`, \`criticality:medium\`, \`criticality:low\`
- PR origin: \`polecat\`

Idempotent — same block can be re-run against existing repos to backfill.

## Test plan
- [ ] Run the new block against a fresh test repo; confirm all labels created with correct colours/descriptions.
- [ ] Re-run against the same repo; confirm \`--force\` upserts without error.
- [ ] Run against a repo that already has \`task\`/\`bug\`; confirm the existing labels are preserved (or updated to canonical colour) without breakage.
- [ ] After backfilling \`triage:*\` on tracked repos, confirm next \`dump_pr_state.py\` cron cycle produces populated \`open_prs\`/\`recent_merged\` for previously-bailing repos without any warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)