### PR TITLE
fix(install): tolerate missing aops-tools in dist marketplace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,8 +186,9 @@ install-gemini:
 	-command gemini extensions uninstall $(GEMINI_EXT_NAME)
 	-command gemini extensions uninstall $(GEMINI_TOOLS_EXT_NAME)
 	@command gemini extensions install $(GEMINI_REMOTE_URL) --consent --auto-update --pre-release && \
-	command gemini extensions install $(GEMINI_TOOLS_REMOTE_URL) --consent --auto-update --pre-release && \
-	echo "✓ Gemini CLI extension installed"
+	echo "✓ Gemini CLI aops-core extension installed"
+	@command gemini extensions install $(GEMINI_TOOLS_REMOTE_URL) --consent --auto-update --pre-release \
+		|| echo "  ⚠️ Gemini aops-tools install failed — release asset missing from $(GEMINI_TOOLS_REMOTE_URL) (next dist build should restore it)"
 
 report-versions:
 	@echo "--- 📋 Installed Versions ---"

--- a/Makefile
+++ b/Makefile
@@ -163,8 +163,9 @@ install-claude:
 	@command claude plugin marketplace add $(DIST_REPO) && \
 	command claude plugin marketplace update academicOps && \
 	command claude plugin install $(CLAUDE_PLUGIN_NAME) && \
-	command claude plugin install $(CLAUDE_TOOLS_PLUGIN_NAME) && \
-	echo "✓ Claude Code plugin installed"
+	echo "✓ Claude Code aops-core installed"
+	@command claude plugin install $(CLAUDE_TOOLS_PLUGIN_NAME) \
+		|| echo "  ⚠️ Claude aops-tools install failed — plugin source missing from $(DIST_REPO_URL) marketplace (next dist build should restore it)"
 
 # Cowork on personal accounts has no marketplace mechanism. The same aops-core
 # plugin shipped to Claude Code CLI is uploaded to Cowork as a zip via


### PR DESCRIPTION
## Summary
- `make install` aborts when the upstream dist marketplace declares `aops-tools` but the matching `aops-tools-claude/` directory isn't shipped — current state of nicsuzor/aops (its live build.yml is stale and silently skips the rsync added in #725).
- The `&&` chain in `install-claude` kills aops-core install + gemini install + crontab setup along with it.
- Split the aops-tools claude install onto its own line so it's best-effort with a warning, matching how `install-dev` (line 111) already handles the same case.

## Root cause (out of scope here, for follow-up)
The live workflow at `nicsuzor/aops/.github/workflows/build.yml` is missing the two rsync lines added to the reference copy at `.github/aops-dist/build.yml` by #725:
```
[ -d "source/dist/aops-tools-claude" ] && rsync -a --delete source/dist/aops-tools-claude/  dist-repo/aops-tools-claude/
[ -d "source/dist/aops-tools-gemini" ] && rsync -a --delete source/dist/aops-tools-gemini/  dist-repo/aops-tools-gemini/
```
That live workflow needs syncing from the reference, and a fresh dispatch needs to be triggered, before aops-tools will actually install.

## Test plan
- [x] `make install-claude` on nicwin: aops-core installs cleanly; aops-tools failure prints a single warning instead of aborting the recipe.
- [ ] After live workflow at nicsuzor/aops is synced + a fresh dispatch, `make install` installs both plugins without the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)