### PR TITLE
revert(pyproject): drop prototype-exclude smuggled into PR #1119

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,6 @@ exclude = [
   "aops-core/policies/", # Exclude policy docs
   "aops-core/scripts/", # Exclude scripts
   "aops-core/skills/", # Exclude skill definitions (YAML)
-  "scripts/*_prototype.py", # Exclude scratch/prototype files
 ]
 ignore = ["**/site-packages"]
 # Python path for internal imports - be specific about Python subdirs only


### PR DESCRIPTION
Partially reverts #1119 (merge 0cc1384) — drops only the `pyproject.toml` hunk that added `scripts/*_prototype.py` to the basedpyright `exclude` list. That hunk was not the intent of #1119 and rode in by accident from an earlier round of the same task.

The ruleset YAML change in 0cc1384 (disabling the Type Check required-check) stays on main — untouched.

Type-check is currently disabled at the ruleset level; this revert keeps the suppression chain in `pyproject.toml` honest with that decision. Principled cleanup of the full suppression chain is tracked by burn-down task **aops-1c3de214** (restore Type Check gate).