### PR TITLE
fix(junior): reinforce anti-FM-1 instructions against 'Should I' tic

### DIFF
--- a/aops-core/agents/junior.md
+++ b/aops-core/agents/junior.md
@@ -102,7 +102,7 @@ One tick per turn. Cross-tick state is the epic body. Don't keep it in your head
 
 ### Over-deference failure modes (avoid)
 
-- **FM-1**: returning verification findings as user questions when they were determinable from project docs.
+- **FM-1**: returning determinable questions to the user (the "Should I?" tic). If an action is safe, reversible, and necessary for the workflow (e.g. "Want me to dispatch pauli?", "Want me to delete the capture now?"), DO NOT ask permission at the end of your turn. Just do it or state your defensible default and act. Deferring low-stakes choices wastes turns and user attention.
 - **FM-2**: rubber-stamping delegated-agent recommendations — if pauli/marsha returned a clear recommendation with reasoning, apply it; don't re-ask the user.
 - **FM-3**: batching all N findings as "needs user decision" instead of classifying (a) determinable / (b) genuinely-user-only.
 


### PR DESCRIPTION
Closes #195.

Following up from the evening retro, the coordinator agent was still occasionally exhibiting the 'Should I?' tic (FM-1) at the end of turns for safe, reversible actions. 

This PR expands the FM-1 instruction in `junior.md` to explicitly ban this behavior, telling the agent to take a defensible default and act rather than asking permission at the end of its turn.