### PR TITLE
fix(build): drop unused gemini core_mcps assignment to unblock lint CI

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1207,7 +1207,7 @@ def main():
     generate_reusable_workflows(aops_root, dist_root)
 
     # Build components (Gemini)
-    core_mcps_gemini = build_aops_core(aops_root, dist_root, aca_data_path, "gemini", version)
+    build_aops_core(aops_root, dist_root, aca_data_path, "gemini", version)
 
     # Build components (Claude)
     build_aops_core(aops_root, dist_root, aca_data_path, "claude", version)


### PR DESCRIPTION
## Summary

Lint CI was failing on `main` with a single Ruff F841 violation in `scripts/build.py:1210`:

```
F841 Local variable `core_mcps_gemini` is assigned to but never used
```

The gemini `build_aops_core(...)` call was assigning its return to `core_mcps_gemini`, but nothing downstream consumed it. The sibling claude and antigravity calls already discard their return values, so this assignment was an orphaned leftover.

Fix: drop the assignment and call `build_aops_core(...)` directly, matching the sibling calls.

## Test plan

- [x] `uv run ruff check` — passes locally
- [x] `uv run ruff format --check` — 224 files already formatted
- [ ] Lint CI green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_011cQRe5Ym4PpWWyk1zgxJZ6)_