### PR TITLE
docs: document gate configuration for users and fix resolution path

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ export ENFORCER_GATE_MODE=block     # stricter compliance checking
 
 The full list: `HANDOVER_GATE_MODE`, `QA_GATE_MODE`, `ENFORCER_GATE_MODE`, `IDA_GATE_MODE`, `HYDRATION_GATE_MODE`, `ENFORCER_TOOL_CALL_THRESHOLD`.
 
-**3. Per-directory overrides** — to change gate behaviour for a specific project, set the environment variables in that project directory's local CLI settings (e.g., for a project where you always want handover off).
+3. Per-directory overrides - to change gate behaviour for a specific project, set the environment variables in your shell environment. Note: on Mac/WSL host, environment variables set in CLI settings env blocks do not reliably reach the hooks. See GATES.md for technical details.
 
 For the detailed gate reference (state machines, triggers, debugging), see [`aops-core/GATES.md`](aops-core/GATES.md).
 

--- a/README.md
+++ b/README.md
@@ -235,11 +235,11 @@ command claude plugin marketplace add nicsuzor/aops
 
 ## Configuration
 
-The framework is designed to work with minimal configuration. Default values are resolved in order:
+The framework works out of the box after installation. Sensible defaults apply — all quality gates warn (agents see reminders without being blocked) and project repos are auto-discovered by convention.
 
-1. Environment variables (set in your shell or `.env.local`)
-2. `~/.env.local` file
-3. Framework defaults (e.g., local `pkb` binary for MCP)
+### Environment variables
+
+Set these in your shell profile (`~/.zshenv`, `~/.bashrc`, or equivalent):
 
 | Variable              | Purpose                                                | Default                         |
 | --------------------- | ------------------------------------------------------ | ------------------------------- |
@@ -249,10 +249,7 @@ The framework is designed to work with minimal configuration. Default values are
 | `PKB_MCP_URL`         | Endpoint for the PKB MCP server                        | (local stdio fallback)          |
 | `AOPS_POLECAT_CONFIG` | Explicit path to `polecat.yaml` (skips env resolution) | (resolved via `$AOPS_SESSIONS`) |
 
-The project registry is the checked-in `$AOPS_SESSIONS/polecat.yaml`. Path
-resolution is convention-based (`$AOPS_SRC_DIR/<repo>`); for off-convention
-repos, add a `paths:` entry to `$POLECAT_HOME/local.yaml` (the only
-machine-local config file polecat reads):
+The project registry lives in `$AOPS_SESSIONS/polecat.yaml`. Path resolution is convention-based (`$AOPS_SRC_DIR/<repo>`); for off-convention repos, add a `paths:` entry to `$POLECAT_HOME/local.yaml`:
 
 ```yaml
 # $POLECAT_HOME/local.yaml
@@ -261,11 +258,61 @@ paths:
   myproject: /opt/work/myproject
 ```
 
-To override the default MCP server (e.g., if running a remote server), add to `~/.env.local`:
+### Gates (quality checks)
+
+Gates are runtime quality checks that fire during sessions. They catch common failure modes — exiting without committing, claiming "done" without verification, scope drift in long sessions.
+
+| Gate        | What it catches                                             | Default |
+| ----------- | ----------------------------------------------------------- | ------- |
+| `ida`       | Honesty / criterion-substitution check before stopping      | `warn`  |
+| `handover`  | Exiting without committing, updating tasks, or reflecting   | `warn`  |
+| `qa`        | Claiming "done" without running verification                | `warn`  |
+| `enforcer`  | Scope drift / compliance in long-running sessions           | `warn`  |
+| `hydration` | Context injection on user prompts (reserved, not yet gated) | `off`   |
+
+Each gate runs in one of three modes: **`warn`** (reminds the agent but doesn't block), **`block`** (stops the agent until the condition is met), or **`off`** (disabled).
+
+#### How to configure gates
+
+There are three ways to configure gates, depending on how you run your sessions:
+
+**1. `polecat.yaml`** — for polecat-managed sessions (autonomous workers and crew). This is the primary configuration file:
+
+```yaml
+# $AOPS_SESSIONS/polecat.yaml
+session_defaults:
+  gates:
+    handover: warn      # warn | block | off
+    qa: warn
+    enforcer: warn
+    ida: warn
+    hydration: off
+    enforcer_threshold: 50   # write ops between enforcer checks
+
+# Override per session type
+run_defaults:             # autonomous polecat workers
+  gates:
+    handover: block       # workers must hand over before exiting
+    enforcer: block
+    enforcer_threshold: 30
+
+crew_defaults: {}         # interactive crew sessions (inherits session_defaults)
+```
+
+See [`polecat/defaults/polecat.yaml.example`](polecat/defaults/polecat.yaml.example) for the full schema.
+
+**2. Environment variables** — for direct CLI sessions (Claude Code or Gemini on your machine). The plugin's built-in defaults apply automatically; override individual gates by setting environment variables in your shell:
 
 ```bash
-export PKB_MCP_URL="http://localhost:3001/mcp"
+export HANDOVER_GATE_MODE=off       # skip handover for quick interactive chats
+export ENFORCER_GATE_MODE=block     # stricter compliance checking
 ```
+
+The full list: `HANDOVER_GATE_MODE`, `QA_GATE_MODE`, `ENFORCER_GATE_MODE`, `IDA_GATE_MODE`, `HYDRATION_GATE_MODE`, `ENFORCER_TOOL_CALL_THRESHOLD`.
+
+**3. Per-directory overrides** — to change gate behaviour for a specific project, set the environment variables in that project directory's local CLI settings (e.g., for a project where you always want handover off).
+
+For the detailed gate reference (state machines, triggers, debugging), see [`aops-core/GATES.md`](aops-core/GATES.md).
 
 ## Development setup
 

--- a/aops-core/GATES.md
+++ b/aops-core/GATES.md
@@ -49,38 +49,55 @@ Every gate above resolves its mode through the same path. Read this section once
 - **Example / schema**: `polecat/defaults/polecat.yaml.example`.
 - **Loader**: [`lib/polecat_config.py:load_polecat_config()`](lib/polecat_config.py).
 
-`polecat.yaml` is the **only** place gate-mode values are configured. Setting `*_GATE_MODE` env vars in `~/.claude/settings.json` is a no-op — see the "Removed" section at the bottom of `polecat.yaml.example`.
+For polecat sessions, `polecat.yaml` is the primary configuration source — the polecat launcher reads it and stages the resolved gate modes as environment variables into the container. For direct CLI sessions (no polecat), the plugin's built-in defaults apply; override individual gates via environment variables in your shell or per-directory CLI settings. See the [README § Gates](../README.md#gates-quality-checks) for user-facing configuration instructions.
 
 ### Resolution path
 
+`gate_config.py` reads gate modes from **environment variables** at runtime, with hardcoded fallback defaults. The polecat launcher is the intermediary that reads `polecat.yaml` and sets these env vars:
+
 ```
-polecat.yaml gates.{name}
-  ↓ parsed by lib/polecat_config.py
-PolecatConfig.session_defaults.gates
-  ↓ .for_mode(POLECAT_SESSION_TYPE) overlay
-hooks/gate_config.py:_resolve_gate_modes()   (lazy via PEP 562 __getattr__)
-  ↓
-ENFORCER_GATE_MODE, QA_GATE_MODE, HANDOVER_GATE_MODE, HYDRATION_GATE_MODE, IDA_GATE_MODE
-  ↓
-imported by lib/gates/definitions.py at module load
-  ↓ embedded in GatePolicy.verdict for each GateConfig
-runtime: lib/gates/engine.py:GenericGate._evaluate_policies
-  ↓
-GateResult.verdict ∈ {allow, warn, deny}
+┌─ Polecat-launched sessions ─────────────────────────────────────────┐
+│                                                                     │
+│  polecat.yaml gates.{name}                                          │
+│    ↓ parsed by lib/polecat_config.py                                │
+│  PolecatConfig.session_defaults.gates                               │
+│    ↓ .for_mode(POLECAT_SESSION_TYPE) overlay                        │
+│  polecat/cli.py stages resolved modes as env vars into container    │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+                              ↓
+              *_GATE_MODE env vars in the process environment
+              (ENFORCER_GATE_MODE, QA_GATE_MODE, etc.)
+                              ↓
+┌─ All sessions (polecat or direct CLI) ──────────────────────────────┐
+│                                                                     │
+│  hooks/gate_config.py:__getattr__   (PEP 562 lazy resolution)      │
+│    reads os.environ.get(name, default)                              │
+│    ↓                                                                │
+│  imported by lib/gates/definitions.py at module load                │
+│    ↓ embedded in GatePolicy.verdict for each GateConfig             │
+│  runtime: lib/gates/engine.py:GenericGate._evaluate_policies        │
+│    ↓                                                                │
+│  GateResult.verdict ∈ {allow, warn, deny}                           │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
 ```
+
+For **direct CLI sessions** (Claude Code or Gemini without polecat), no launcher sets the env vars, so `gate_config.py` falls back to its built-in defaults: all gates `warn`, hydration `off`, threshold 50. To override, set the env vars in your shell profile or per-directory CLI settings.
 
 `gate_config.py` uses module-level `__getattr__` so config values are resolved lazily on first access — this is what lets tests monkeypatch the session env after the module is imported (call `_reset_gate_mode_cache()` to invalidate).
 
-### Session-type overlays
+### Session-type overlays (polecat sessions)
 
-`POLECAT_SESSION_TYPE` (set by `polecat/cli.py` at launch) selects the overlay:
+`POLECAT_SESSION_TYPE` (set by `polecat/cli.py` at launch) selects which overlay from `polecat.yaml` is applied on top of `session_defaults`:
 
-| Value         | Overlay applied to defaults                                  | Surfaces                                                    |
-| ------------- | ------------------------------------------------------------ | ----------------------------------------------------------- |
-| `crew`        | `polecat.yaml:crew_defaults` (today: `hooks_enabled: false`) | `polecat crew` interactive multi-agent sessions             |
-| (unset/`run`) | `polecat.yaml:run_defaults` (today: `{}`)                    | `polecat run` workers, host-Claude sessions, fresh installs |
+| Value   | Overlay applied to defaults                                       | Surfaces                                        |
+| ------- | ----------------------------------------------------------------- | ----------------------------------------------- |
+| `crew`  | `polecat.yaml:crew_defaults`                                      | `polecat crew` interactive multi-agent sessions |
+| `run`   | `polecat.yaml:run_defaults`                                       | `polecat run` autonomous workers                |
+| (unset) | No overlay — built-in defaults in `gate_config.py` apply directly | Direct CLI sessions (not polecat-launched)      |
 
-If unset the loader treats it as `run` — so host sessions get `run_defaults`.
+For direct CLI sessions, `POLECAT_SESSION_TYPE` is not set and polecat is not involved. The hook code reads env vars directly with its own defaults.
 
 ### Plugin cache lifecycle
 
@@ -94,9 +111,9 @@ To verify the cached copy matches source: `diff -ru ~/src/academicOps/aops-core/
 
 ### Hook env stripping (cross-cutting trap)
 
-On Claude Code CLI on host (Mac, WSL host shell): `settings.json` `env` block does **not** propagate to hook subprocesses (`launchctl setenv` ignored; `.zshenv` partially sourced but `PATH` overridden). All gate-mode env vars in `settings.json` are dead by design — `gate_config.py` reads only from `polecat.yaml`. If `$AOPS_SESSIONS` is missing from the hook env, `gate_config.py` raises at import. See [`SURFACES.md`](SURFACES.md) → "Claude Code CLI on host" → Known traps for the full trace.
+On Claude Code CLI on host (Mac, WSL host shell): the `env` block in CLI settings does **not** reliably propagate to hook subprocesses (`launchctl setenv` ignored; `.zshenv` partially sourced but `PATH` overridden). Gate-mode env vars set there may not reach the hooks. For direct CLI sessions, set gate env vars in your shell profile (`~/.zshenv`, `~/.bashrc`) instead, so they are in the process environment before Claude Code launches. See [`SURFACES.md`](SURFACES.md) → "Claude Code CLI on host" → Known traps for the full trace.
 
-The WSL crew container surface receives env directly from the polecat launcher; no `launchctl`/`.zshenv` hop, so this trap does not apply there.
+The WSL crew container and polecat-launched sessions receive env directly from the polecat launcher; no `launchctl`/`.zshenv` hop, so this trap does not apply there.
 
 ### Verifying the resolved mode at runtime
 

--- a/aops-core/SURFACES.md
+++ b/aops-core/SURFACES.md
@@ -218,9 +218,9 @@ Asynchronous Google-infra worker. Receives a task spec, returns a session URL, e
 
 ### Hook env stripping (load-bearing bug across Mac/CLI host surfaces)
 
-`settings.json`'s `env` block does NOT propagate into hook subprocesses on Mac/CLI host surfaces. `launchctl setenv` is ignored by Claude.app; `.zshenv` is partially sourced but `PATH` is overridden. `gate_config.py` (post-2026-03 cleanup) hard-fails when `$AOPS_SESSIONS` or `$AOPS_POLECAT_CONFIG` is absent — there are no env-var fallbacks by design.
+The `env` block in CLI settings does NOT propagate into hook subprocesses on Mac/CLI host surfaces. `launchctl setenv` is ignored by Claude.app; `.zshenv` is partially sourced but `PATH` is overridden. `gate_config.py` reads gate modes directly from environment variables (`os.environ.get`) with built-in defaults — it does not read `polecat.yaml` itself. The polecat launcher is the intermediary that reads `polecat.yaml` and stages the resolved modes as env vars.
 
-**Net effect**: any gate reading `polecat.yaml` crashes on hook import on Mac/CLI host surfaces. PreToolUse path appears to fire correctly (custodiet works); Stop/SessionEnd paths crash silently.
+**Net effect on direct CLI sessions**: gates fall back to built-in defaults (all `warn`, hydration `off`) since no polecat launcher sets the env vars. To override, set `*_GATE_MODE` env vars in your shell profile (`~/.zshenv` / `~/.bashrc`), not in CLI settings.
 
 **Scope**: this bug bites surfaces that go through `launchctl` / `.zshenv` to reach hook subprocesses — i.e. the Mac/CLI host surfaces above. The WSL crew container and `polecat run/crew` containers receive env directly at container launch and are **not** affected.
 
@@ -240,9 +240,17 @@ Tracking: archived-but-still-true [academicops-459eb8f3] and [aops-1bf76d85]. Re
 
 Implication: when shipping a plugin change, multiple consumers need to pick it up via different mechanisms. PR landing isn't propagation.
 
-### Mode resolution (crew vs run)
+### Mode resolution (crew vs run vs direct)
 
-`gate_config.py:432-433` reads `POLECAT_SESSION_TYPE`. Value `crew` → crew-mode overlay; anything else → run-mode overlay. The "anything else" includes the host (Claude Code CLI on laptop) — host sessions resolve to **run mode** by default, not a separate "host" mode. This is implicit; no doc names it as a design decision. The WSL crew container surface resolves to **crew mode** (it is a `polecat crew` session).
+The polecat launcher reads `POLECAT_SESSION_TYPE` and applies the corresponding overlay from `polecat.yaml` before staging env vars into the container. `gate_config.py` itself does not read `POLECAT_SESSION_TYPE` — it only reads the resulting `*_GATE_MODE` env vars.
+
+| `POLECAT_SESSION_TYPE` | Config overlay applied by launcher                   | Surfaces                                           |
+| ---------------------- | ---------------------------------------------------- | -------------------------------------------------- |
+| `crew`                 | `polecat.yaml:crew_defaults` over `session_defaults` | `polecat crew` sessions (incl. WSL crew container) |
+| `run`                  | `polecat.yaml:run_defaults` over `session_defaults`  | `polecat run` autonomous workers                   |
+| (unset)                | None — `gate_config.py` built-in defaults apply      | Direct CLI sessions (not polecat-launched)         |
+
+For direct CLI sessions, no polecat launcher is involved. `gate_config.py` falls back to its built-in defaults (all `warn`, hydration `off`). Override via env vars in your shell profile or per-directory CLI settings.
 
 ---
 

--- a/polecat/defaults/polecat.yaml.example
+++ b/polecat/defaults/polecat.yaml.example
@@ -42,17 +42,27 @@ session_defaults:
     enforcer_threshold: 50
 
 # ---------------------------------------------------------------------------
-# Per-session-type overlays. Both blocks MUST exist (use {} when empty).
+# Per-session-type overlays. All blocks MUST exist (use {} when empty).
 # Keys present here override the matching key in session_defaults for that
 # session type. Supports nested ``gates: {...}`` overrides.
+#
+# For direct CLI sessions (POLECAT_SESSION_TYPE unset), no overlay is
+# applied — gate_config.py falls back to its built-in defaults (all warn,
+# hydration off). Override individual gates via env vars in your shell
+# profile or per-directory CLI settings.
 # ---------------------------------------------------------------------------
 
-# `polecat crew` — interactive multi-agent sessions. Today's default mirrors
-# the "vanilla crew" trial: hooks off, bypass permissions.
-crew_defaults:
-  hooks_enabled: false
+# `polecat crew` — interactive multi-agent sessions. Inherits
+# session_defaults; override specific gates as needed.
+crew_defaults: {}
 
 # `polecat run` — autonomous workers. Hooks always on, full policy.
+# To tighten enforcement for unsupervised sessions, replace {} with:
+#   run_defaults:
+#     gates:
+#       handover: block
+#       enforcer: block
+#       enforcer_threshold: 30
 run_defaults: {}
 
 # ---------------------------------------------------------------------------

--- a/scripts/manifest.py
+++ b/scripts/manifest.py
@@ -58,7 +58,7 @@ MANIFEST = [
             "aops-core/**/__pycache__/*",
             "aops-core/pyproject.toml",
             "aops-core/indices/*",
-            "aops-core/.*", # .mcp.json etc
+            "aops-core/.*",  # .mcp.json etc
         ],
         "transforms": [],
         "runtimes": ["gemini", "claude"],

--- a/scripts/transforms/agent_schema.py
+++ b/scripts/transforms/agent_schema.py
@@ -71,6 +71,7 @@ CLAUDE_TOOL_NAME_MAP = {
     "browser_resize": "browser_resize",
 }
 
+
 def _validate_gemini_agent_schema(frontmatter: dict, filename: str) -> dict:
     errors = []
     if "name" not in frontmatter or not frontmatter["name"]:
@@ -78,18 +79,24 @@ def _validate_gemini_agent_schema(frontmatter: dict, filename: str) -> dict:
     else:
         name = frontmatter["name"]
         if not re.match(r"^[a-z0-9_-]+$", name):
-            errors.append(f"Invalid name '{name}': must be lowercase with only letters, numbers, hyphens, and underscores")
+            errors.append(
+                f"Invalid name '{name}': must be lowercase with only letters, numbers, hyphens, and underscores"
+            )
 
     if "description" not in frontmatter or not frontmatter["description"]:
         errors.append("Missing required field: description")
 
     if errors:
-        raise ValueError(f"Agent '{filename}' schema validation failed:\n  - " + "\n  - ".join(errors))
+        raise ValueError(
+            f"Agent '{filename}' schema validation failed:\n  - " + "\n  - ".join(errors)
+        )
 
     if "kind" not in frontmatter:
         frontmatter["kind"] = "local"
     elif frontmatter["kind"] not in ("local", "remote"):
-        raise ValueError(f"Agent '{filename}': kind must be 'local' or 'remote', got '{frontmatter['kind']}'")
+        raise ValueError(
+            f"Agent '{filename}': kind must be 'local' or 'remote', got '{frontmatter['kind']}'"
+        )
 
     CLAUDE_TO_GEMINI_MODEL = {
         "opus": "gemini-3-pro-preview",
@@ -110,12 +117,22 @@ def _validate_gemini_agent_schema(frontmatter: dict, filename: str) -> dict:
     if "timeout_mins" not in frontmatter:
         frontmatter["timeout_mins"] = 5
 
-    GEMINI_ALLOWED_KEYS = {"name", "description", "kind", "tools", "model", "temperature", "max_turns", "timeout_mins"}
+    GEMINI_ALLOWED_KEYS = {
+        "name",
+        "description",
+        "kind",
+        "tools",
+        "model",
+        "temperature",
+        "max_turns",
+        "timeout_mins",
+    }
     for key in list(frontmatter.keys()):
         if key not in GEMINI_ALLOWED_KEYS:
             del frontmatter[key]
 
     return frontmatter
+
 
 def gemini_agent_schema(content: str, ctx: dict) -> str:
     parts = content.split("---", 2)
@@ -148,6 +165,7 @@ def gemini_agent_schema(content: str, ctx: dict) -> str:
     frontmatter = _validate_gemini_agent_schema(frontmatter, ctx.get("filename", "agent"))
     new_frontmatter = yaml.dump(frontmatter, default_flow_style=False, sort_keys=False)
     return f"---\n{new_frontmatter}---{parts[2]}"
+
 
 def claude_agent_schema(content: str, ctx: dict) -> str:
     parts = content.split("---", 2)

--- a/scripts/transforms/hooks.py
+++ b/scripts/transforms/hooks.py
@@ -26,6 +26,7 @@ VALID_GEMINI_EVENTS = (
     "SessionEnd",
 )
 
+
 def gemini_hooks(content: str, ctx: dict) -> str:
     try:
         config = json.loads(content)

--- a/scripts/transforms/tool_translation.py
+++ b/scripts/transforms/tool_translation.py
@@ -49,6 +49,7 @@ def _translate_tool_calls(text: str, platform: str) -> str:
         text = text.replace("${CLAUDE_PLUGIN_ROOT}", "${extensionPath}")
 
         import re
+
         text = re.sub(r"mcp__([a-zA-Z0-9_-]+)__([a-zA-Z0-9_-]*)", r"mcp_\1_\2", text)
 
         text = text.replace("Task(subagent_type=", "activate_skill(name=")
@@ -59,8 +60,10 @@ def _translate_tool_calls(text: str, platform: str) -> str:
 
     return text
 
+
 def translate_tool_calls_claude(content: str, ctx: dict) -> str:
     return _translate_tool_calls(content, "claude")
+
 
 def translate_tool_calls_gemini(content: str, ctx: dict) -> str:
     return _translate_tool_calls(content, "gemini")


### PR DESCRIPTION
The README now has a user-facing Gates section explaining what each gate
does and the three ways to configure them (polecat.yaml, env vars,
per-directory settings). GATES.md resolution path corrected to reflect
the actual architecture: gate_config.py reads env vars directly, not
polecat.yaml — the polecat launcher is the intermediary. SURFACES.md
mode-resolution section updated to match. polecat.yaml.example synced
with live config (crew_defaults is now {} per #940).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
