### PR TITLE
spec(enforcement): fix axiom-as-mechanism pyramid + surface base-of-pyramid vectors (Phase A.5)

### DIFF
--- a/specs/ENFORCEMENT-MAP.md
+++ b/specs/ENFORCEMENT-MAP.md
@@ -1,41 +1,48 @@
 # Enforcement Map
 
-> **SSoT (state).** Maps each axiom and load-bearing rule to the
-> mechanism(s) currently enforcing it — answers **how is rule X enforced
-> today?** Any PR that adds, escalates, or retires enforcement updates a
-> row here in the same change (P#65); `rbg` blocks on map currency.
+> **State.** Routing table for "how is each rule currently enforced?". Any PR that adds, escalates, or retires a mechanism updates a row here in the same change (P#65); `rbg` blocks on currency.
 >
-> Enforcement is a **regulatory pyramid** (Ayres & Braithwaite 1992,
-> _Responsive Regulation_): wide base of high-volume soft mechanisms
-> (instructions, conventions, hints), narrowing to a sharp apex of rare
-> severe responses (hard blocks, axioms, branch protection). Positions
-> **L0–L7** below mark where each mechanism sits; the width at each
-> level tracks frequency × marginal cost there. Pyramid framing,
-> escalation discipline, PR cost-benefit requirements, and the worked
-> A7 example live in
-> [`specs/enforcement/enforcement.md`](enforcement/enforcement.md).
-> This file is the operative register; that spec is the framing.
->
-> **Adjacent state SSoT.** Per-gate forensic-debug detail (source path,
-> `polecat.yaml` config, how to verify firing, how to debug) →
-> [`specs/GATES.md`](GATES.md). Both are state.
+> Framing, escalation discipline, PR cost-benefit, and the worked A7 example → [`specs/enforcement/enforcement.md`](enforcement/enforcement.md). Per-gate forensic detail (config, verify, debug) → [`specs/GATES.md`](GATES.md). Both adjacent files are state.
 
-## Pyramid positions (L0–L7)
+## Pyramid (L0–L7)
 
-Lower numbers sit at the **wide base** (high volume, low invasiveness); higher numbers sit toward the **apex** (rare, severe). Add/escalate/remove decisions cite a row of this file plus the position justifying the change. Costs are **marginal** per-fire; combine with frequency for per-session totals. Numbers are order-of-magnitude — measure when proposing.
+Rows are **mechanism categories** on a coercion-strength × frequency axis. A tier holds **multiple blocks** at the same coercion level. Axioms (rules) do **not** appear as pyramid rows — they are the *content* L1 always-on mechanisms carry. Executive/legislative distinction and escalation discipline → [`enforcement.md`](enforcement/enforcement.md) §4. Costs are order-of-magnitude per fire; combine with frequency for per-session totals.
 
-| L  | Mechanism                            | Marginal cost                               | When justified                                            |
-| -- | ------------------------------------ | ------------------------------------------- | --------------------------------------------------------- |
-| L0 | PKB note / inline comment            | ~0                                          | Any time                                                  |
-| L1 | Skill SKILL.md / CORE.md text        | ~50–500 tok/session (prompt-cached)         | Recurrent friction (≥3 instances), clear callsite         |
-| L2 | Mechanical check (pre-commit/bridge) | ~50ms–2s wall-clock                         | Mechanical, deterministic; no judgement                   |
-| L3 | Stop-hook injection (always-on)      | ~400–4k tok in-window (compounds on retry)  | Cross-cutting + agent forgets between turns               |
-| L4 | PreToolUse gate (`warn`)             | ~20–800 tok per fire; no model dispatch     | Periodic compliance check without LLM                     |
-| L5 | PreToolUse gate (`block`)            | ~100–500 tok + tool-call latency            | Hard-block needed; destructive / legal / privacy          |
-| L6 | LLM-gated hook (subagent per fire)   | ~1.5–3k tok + 5–30s latency                 | Last resort; structural fixes (L1–L3) have failed         |
-| L7 | Numbered axiom (A-tier)              | Permanent context burn (~100 lines, cached) | Must beat trained reflex; cross-cutting; primary contract |
+| L  | Class      | Mechanism categories (multiple blocks per tier)                                                                                                                                  | Marginal cost                              |
+| -- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| L0 | base       | **Authoring memory**: PKB notes · inline comments · doc-strings                                                                                                                  | ~0                                         |
+| L1 | base       | **SessionStart guaranteed reads**: CORE.md · AXIOMS.md · HEURISTICS.md · agent persona · status strip · `session_env_setup` env vars                                             | ~50–500 tok/session, prompt-cached         |
+| L2 | base       | **Lifecycle context injection**: UPS hints (`context-map.json`) · hydrator · Stop-hook reminders (IDA, QA-gate, handover-gate)                                                   | ~50–500 tok per event                      |
+| L3 | base       | **Voluntary skill invocation**: `/verify` · `/design-rubric` · `/q` · `/pull` · `/learn` · others (agent opts in)                                                                | per-skill, agent decides                   |
+| L4 | middle     | **Mechanical checks (deterministic, no LLM)**: pre-commit hooks · bridge guards · `aca_data_autocommit` · `fail_fast_watchdog` · `normalize_mcp_names` · `orchestrator_boundary` | 50ms–2s wall-clock                         |
+| L5 | middle     | **PreToolUse classifier**: auto-mode warn rules · auto-mode block rules · `policy_enforcer` hard-deny                                                                            | ~20–800 tok per fire + tool-call latency   |
+| L6 | tip        | **LLM-mediated review subagent**: `rbg` · `marsha` · `enforcer` subagent · `alignment`                                                                                           | ~1.5–3k tok + 5–30s latency                |
+| L7 | tip (apex) | **Branch protection + merge AND-gates**: branch protection rules · `loop_detector` · `<agent>-status` AND-checks · project-owner / admin approval                                | merge-blocking, irreversible at the moment |
 
-> **Anti-pattern**: jumping to L3+ when the actual failure is recurrence at a single L1 callsite. Most over-deference recurrences (issue #195) were L1 fixes that propagated incompletely, not failures of L1 as a position.
+## Lifecycle
+
+Which pyramid tiers fire at which event in the session/PR lifecycle. The pyramid says **how invasive**; the lifecycle says **when**.
+
+```mermaid
+flowchart LR
+  SS[SessionStart]            -->|L1 inject| UPS[UserPromptSubmit]
+  UPS                         -->|L2 inject| PTU[PreToolUse]
+  PTU                         -->|L4 mech / L5 classifier| TOOL[tool exec]
+  TOOL                        -->|L4 mech| PTU2[PostToolUse]
+  PTU2                        -->|L2 inject / L6 review| STOP[Stop]
+  STOP                        -->|L4 hooks| COM[commit]
+  COM                         -->|L4 / L5 / L6| PR[PR push]
+  PR                          -->|L6 LLM review| MERGE((merge))
+  MERGE                       -.->|L7 AND-gate| Done([done])
+  classDef base fill:#e6f3ff,stroke:#1e6091,color:#000
+  classDef mid  fill:#fff4d6,stroke:#a76700,color:#000
+  classDef tip  fill:#ffe1e1,stroke:#a30000,color:#000
+  class SS,UPS,STOP base
+  class PTU,PTU2,COM,PR mid
+  class MERGE tip
+```
+
+L3 (voluntary skill invocation) is omitted from the flow because it's not lifecycle-anchored — agents invoke skills mid-turn at their own discretion.
 
 ## Runtime gates
 
@@ -175,12 +182,12 @@ Each entry: name, pyramid position, purpose, authoritative source. Runtime-gate 
 | Mechanism             | L  | Action     | Purpose                                                | Source                                                                                   |
 | :-------------------- | :- | :--------- | :----------------------------------------------------- | :--------------------------------------------------------------------------------------- |
 | `enforcer` gate       | L6 | warn/block | Periodic axiom-compliance check via subagent           | [`ultra-vires-enforcer.md`](enforcement/ultra-vires-enforcer.md), [`GATES.md`](GATES.md) |
-| `qa` gate             | L3 | warn/block | Requires verification before Stop                      | [`GATES.md`](GATES.md)                                                                   |
-| `handover` gate       | L3 | warn/block | Blocks Stop until commit + task update + reflection    | [`GATES.md`](GATES.md)                                                                   |
-| `ida` gate            | L3 | warn       | Back assertions with proof; disclose skips             | [`GATES.md`](GATES.md)                                                                   |
+| `qa` gate             | L6 | warn/block | Requires verifier subagent before Stop                 | [`GATES.md`](GATES.md)                                                                   |
+| `handover` gate       | L6 | warn/block | Blocks Stop until commit + task update + reflection    | [`GATES.md`](GATES.md)                                                                   |
+| `ida` gate            | L2 | warn       | Stop-hook inject: back assertions with proof           | [`GATES.md`](GATES.md)                                                                   |
 | `hydration` gate      | L4 | warn       | Blocks tool calls until hydrator runs (mode-dependent) | [`GATES.md`](GATES.md)                                                                   |
-| `aca_data_autocommit` | L2 | —          | Auto-commits `$ACA_DATA` after state-modifying calls   | `aops-core/hooks/router.py:_run_aca_data_autocommit`                                     |
-| `context-map hints`   | L1 | inject     | Doc pointers from `.agents/context-map.json` on UPS    | `aops-core/hooks/router.py:_inject_context_map_hints`                                    |
+| `aca_data_autocommit` | L4 | —          | Auto-commits `$ACA_DATA` after state-modifying calls   | `aops-core/hooks/router.py:_run_aca_data_autocommit`                                     |
+| `context-map hints`   | L2 | inject     | UPS lifecycle inject from `.agents/context-map.json`   | `aops-core/hooks/router.py:_inject_context_map_hints`                                    |
 | ~~`policy_enforcer`~~ | —  | —          | **Retired 2026-05-15** (sandbox supersedes)            | `aops-e0d015d9`                                                                          |
 | ~~`commit` gate~~     | —  | —          | **Retired PR #988** (superseded by `handover`)         | —                                                                                        |
 
@@ -188,17 +195,17 @@ Each entry: name, pyramid position, purpose, authoritative source. Runtime-gate 
 
 | Hook                        | L  | Action | Purpose                                                 | Source                                 |
 | :-------------------------- | :- | :----- | :------------------------------------------------------ | :------------------------------------- |
-| `check-no-new-orphan-md`    | L2 | warn   | New `.md` outside canonical-location allowlist (R5.6)   | `scripts/check_no_new_orphan_md.py`    |
-| `check-framework-integrity` | L2 | warn   | Broken wikilinks or missing index entries               | `scripts/check_framework_integrity.py` |
-| `check-no-fallbacks`        | L2 | warn   | Silent-fallback patterns in hooks (A8 / P#8; #930)      | `scripts/check_no_fallbacks.py`        |
-| `normalize-mcp-names`       | L2 | warn   | Auto-heals Gemini-form MCP names to Claude form (#1128) | `scripts/normalize_mcp_names.py`       |
+| `check-no-new-orphan-md`    | L4 | warn   | New `.md` outside canonical-location allowlist (R5.6)   | `scripts/check_no_new_orphan_md.py`    |
+| `check-framework-integrity` | L4 | warn   | Broken wikilinks or missing index entries               | `scripts/check_framework_integrity.py` |
+| `check-no-fallbacks`        | L4 | warn   | Silent-fallback patterns in hooks (A8 / P#8; #930)      | `scripts/check_no_fallbacks.py`        |
+| `normalize-mcp-names`       | L4 | warn   | Auto-heals Gemini-form MCP names to Claude form (#1128) | `scripts/normalize_mcp_names.py`       |
 
 ### Bridge-level constraints
 
 | Constraint                 | L  | Action | Purpose                                       | Source                  |
 | :------------------------- | :- | :----- | :-------------------------------------------- | :---------------------- |
-| `create_task` prefix guard | L2 | block  | ID prefix must match task type / project slug | `polecat/pkb_bridge.py` |
-| `claude` OAUTH pre-flight  | L2 | block  | Exits 4 when `CLAUDE_CODE_OAUTH_TOKEN` unset  | `polecat/cli.py`        |
+| `create_task` prefix guard | L4 | block  | ID prefix must match task type / project slug | `polecat/pkb_bridge.py` |
+| `claude` OAUTH pre-flight  | L4 | block  | Exits 4 when `CLAUDE_CODE_OAUTH_TOKEN` unset  | `polecat/cli.py`        |
 
 ### CORE.md directives
 
@@ -218,10 +225,12 @@ Branch protection AND-gates each `<agent>-status` directly — no LLM judgment i
 
 | Agent              | L     | Action | Purpose                                         | Source                                                          |
 | :----------------- | :---- | :----- | :---------------------------------------------- | :-------------------------------------------------------------- |
-| `enforcer-status`  | L6    | block  | Reviews PR diff against axioms; SHA-skip dedupe | `.github/workflows/agent-enforcer.yml@enforcer-v1`              |
-| `alignment-status` | L6    | block  | PKB design-intent alignment; off-GHA dispatch   | `.github/workflows/agent-alignment.yml@alignment-v1`            |
-| `mechanic-status`  | L4–L6 | —      | Mechanical merge + conflict resolution only     | `.github/workflows/agent-mechanic.yml@mechanic-v1`              |
-| ~~v1 agents~~      | —     | —      | **Retired Phase 1** (PR #1062)                  | [`pr-pipeline-v2.md`](workflows/pr-pipeline-v2.md) §3.1/§3.6/§5 |
+| `enforcer-status`  | L6 | block  | LLM review of PR diff against axioms; SHA-skip dedupe | `.github/workflows/agent-enforcer.yml@enforcer-v1`              |
+| `alignment-status` | L6 | block  | LLM review of PKB design-intent alignment             | `.github/workflows/agent-alignment.yml@alignment-v1`            |
+| `mechanic-status`  | L4 | —      | Mechanical merge + conflict resolution only           | `.github/workflows/agent-mechanic.yml@mechanic-v1`              |
+| branch protection  | L7 | block  | AND-gates all required `<agent>-status` checks at merge | GitHub repo settings (admin-configured)                       |
+| `loop_detector`    | L7 | block  | Refuses merge if loop detected in PR-pipeline state   | `.github/workflows/loop-detector.yml`                           |
+| ~~v1 agents~~      | —  | —      | **Retired Phase 1** (PR #1062)                        | [`pr-pipeline-v2.md`](workflows/pr-pipeline-v2.md) §3.1/§3.6/§5 |
 
 ## Related
 

--- a/specs/ENFORCEMENT-MAP.md
+++ b/specs/ENFORCEMENT-MAP.md
@@ -229,7 +229,7 @@ Branch protection AND-gates each `<agent>-status` directly — no LLM judgment i
 | `alignment-status` | L6 | block  | LLM review of PKB design-intent alignment             | `.github/workflows/agent-alignment.yml@alignment-v1`            |
 | `mechanic-status`  | L4 | —      | Mechanical merge + conflict resolution only           | `.github/workflows/agent-mechanic.yml@mechanic-v1`              |
 | branch protection  | L7 | block  | AND-gates all required `<agent>-status` checks at merge | GitHub repo settings (admin-configured)                       |
-| `loop_detector`    | L7 | block  | Refuses merge if loop detected in PR-pipeline state   | `.github/workflows/loop-detector.yml`                           |
+| `loop_detector`    | L7 | block  | Refuses merge if loop detected in PR-pipeline state   | `.github/workflows/agent-merge-prep.yml` (steps: loop-check, ceiling-check) |
 | ~~v1 agents~~      | —  | —      | **Retired Phase 1** (PR #1062)                        | [`pr-pipeline-v2.md`](workflows/pr-pipeline-v2.md) §3.1/§3.6/§5 |
 
 ## Related

--- a/specs/enforcement/enforcement.md
+++ b/specs/enforcement/enforcement.md
@@ -100,7 +100,9 @@ Full catalogue of mechanisms per layer: **see [`specs/enforcement/enforcement-me
 
 ## §4 Pyramid view (escalation)
 
-**Responsive regulation theory.** The pyramid is borrowed directly from Ian Ayres & John Braithwaite, _Responsive Regulation: Transcending the Deregulation Debate_ (Oxford University Press, 1992). The framework cannot force any agent to do anything — we can only create _encouragement with detection_. Given that, the choice of _where to intervene_ should follow the principle of least invasion: use the lightest mechanism that catches the failure, and escalate only when evidence shows the lighter mechanism is insufficient. The width of the pyramid at each level represents the **volume × frequency** of enforcement there: a wide base of high-volume soft mechanisms (skills, prompts, conventions, hints) tapering to a sharp apex of rare severe responses (hard blocks, numbered axioms, branch protection, recusal-grounded recourse). The narrower the level, the more reluctantly invoked.
+**Responsive regulation theory.** The pyramid is borrowed directly from Ian Ayres & John Braithwaite, _Responsive Regulation: Transcending the Deregulation Debate_ (Oxford University Press, 1992). The framework cannot force any agent to do anything — we can only create _encouragement with detection_. Given that, the choice of _where to intervene_ should follow the principle of least invasion: use the lightest mechanism that catches the failure, and escalate only when evidence shows the lighter mechanism is insufficient. The width of the pyramid at each level represents the **volume × frequency** of enforcement there: a wide base of high-volume soft mechanisms (always-on context injection, voluntary skill invocation, lifecycle hints) tapering to a sharp apex of rare severe responses (LLM-mediated review, branch protection, recusal-grounded recourse). The narrower the level, the more reluctantly invoked.
+
+**Executive vs legislative.** The pyramid is **executive only** — it lists the mechanisms that act on agent behaviour. Axioms (the numbered A-rules in [`.agents/rules/AXIOMS.md`](../../.agents/rules/AXIOMS.md)) and heuristics are **legislative**: they declare what the rules are. The rules don't enforce themselves; they are *enforced by* mechanisms across multiple pyramid tiers. Numbering an axiom raises the *weight* of a rule in the L1 always-on injection mechanism — the numbering is content-weighting, not pyramid placement. Looking up "what enforces A7?" means scanning the axiom × mechanism table in [`specs/ENFORCEMENT-MAP.md`](../../specs/ENFORCEMENT-MAP.md), not the pyramid table.
 
 **Operative use.** The pyramid is **not** a decorative metaphor — it is the structure that organises every add/escalate/remove decision. Each mechanism in [`specs/ENFORCEMENT-MAP.md`](../../specs/ENFORCEMENT-MAP.md) carries an explicit pyramid position (L0–L7); PRs that propose enforcement changes cite that position and justify it against §4.1. The L0–L11 pipeline numbering above and the base/middle/tip tier labels below are different lenses on the same set of mechanisms — the pipeline answers _when_, the pyramid answers _how invasive_.
 
@@ -134,16 +136,25 @@ Reviewers should WARN on missing CBA, BLOCK on missing items 1, 4, or 5.
 
 ### §4.2 Worked example: A7
 
-A7 ("Exercise Authority — Calibrate Capability", `.agents/rules/AXIOMS.md`) sits at **L7**, the apex of the pyramid. The placement is the result of an explicit cost-benefit decision, not a default.
+A7 ("Exercise Authority — Calibrate Capability", `.agents/rules/AXIOMS.md`) is an axiom — a rule, not a pyramid position. Its **enforcement footprint** spans multiple tiers of the executive pyramid:
+
+| Tier | Mechanism enforcing A7 | What it does                                                              |
+| :--- | :--------------------- | :------------------------------------------------------------------------ |
+| L1   | AXIOMS.md inject       | Always-on prompt-cached load at SessionStart; ~100 lines per session.     |
+| L6   | `rbg` PR-time review   | Reads diff against A7; advisory verdict for the orchestrator.             |
+| L6   | `marsha` QA verifier   | Checks task-completion claims for over-deference.                         |
+| L7   | `enforcer-status` GHA  | LLM review fed into branch-protection AND-gate at merge.                  |
+
+The decision to **number** A7 (vs leaving the rule as scattered surface-text instructions) was an explicit cost-benefit decision. Numbering raises the rule's **weight inside the L1 always-on inject mechanism**; it does not move the enforcement to a different tier.
 
 - **Friction**: 9+ over-deference recurrences across 6 agent surfaces (issue #195 thread, issue #950, plus fresh /retro evidence from 2026-05-11 sessions).
-- **Cheaper position attempted first**: L1 (skill instruction text in CORE.md / butler.md / planner). Tried 9 times across the #195 history. Each attempt reached one more surface; the next session hit a surface the patch hadn't reached.
-- **Why escalation justified**: per-surface, permissively-framed L1 fixes did not beat the trained "seek confirmation" reflex. Reframing as an obligation-level axiom (L7) puts equal weight on the no-abdication direction as on the no-ultra-vires direction (the original A7).
-- **Forward cost**: A7's text is ~100 lines in always-on AXIOMS.md, prompt-cached at SessionStart. Surface citations are L1 (≤10 lines each).
-- **Future fixes** against any of A7's three edges should land at the cheapest sufficient position — usually L1 propagation into the specific failing surface, NOT additional axioms. Adding A18/A19 against the same root would repeat the failure mode this PR resolved.
+- **Cheaper position attempted first**: surface-text L1 fixes (per-skill CORE.md / butler.md / planner). Tried 9 times across the #195 history. Each attempt reached one more surface; the next session hit a surface the patch hadn't reached.
+- **Why numbering justified**: per-surface L1 surface-text fixes did not beat the trained "seek confirmation" reflex. Moving the rule into always-on AXIOMS.md (still L1 — same mechanism class) makes it cross-cutting in a way no per-surface edit could match. Numbering is the weight-raising act.
+- **Forward cost**: ~100 lines permanent in always-on AXIOMS.md, prompt-cached. Surface citations remain L1 (≤10 lines each).
+- **Future fixes** against any of A7's three edges should land at the cheapest sufficient position — usually L1 surface-text propagation, not new axioms. Adding A18/A19 against the same root would repeat the failure mode this PR resolved.
 - **Reversibility / acceptance criterion**: zero FM-1 through FM-7 recurrences across the next 5 /retro reviews. If the criterion fails, the documented contingency is L6 (pre-Stop LLM hook), per `note-23e58353`.
 
-This serves as the template for any future L6/L7 escalation: the CBA must look like this, with named prior attempts and explicit reversibility.
+This serves as the template for axiom-weight escalation: the CBA must look like this, with named prior attempts and explicit reversibility. The axiom is the rule; the pyramid tiers are the mechanisms enforcing it — confusing the two leads to inflating the axiom count rather than thickening the enforcement footprint.
 
 ### §4.3 How to update the operative register
 


### PR DESCRIPTION
## What this PR does

Phase A.5 of epic `aops-1458eb7b`. Surgical fix to the two defects that survived Phase A's `done` close (PR #1278), surfaced 2026-05-28.

### 1. Axiom-as-mechanism conceptual error (fixed)

Old pyramid row "L7 = Numbered axiom (A-tier)" conflated legislative (the rule) with executive (the mechanism). New pyramid axis is mechanism category × coercion strength; rows are mechanism categories; tiers hold multiple blocks. Axioms are content carried by L1 always-on mechanisms, not pyramid rows. `enforcement.md` §4 prose updated; §4.2 worked A7 example rewritten as a tier×mechanism table showing A7's enforcement footprint spans L1/L6/L7.

### 2. Base-of-pyramid context-injection vectors (surfaced)

L1 = SessionStart guaranteed reads (CORE/AXIOMS/HEURISTICS/persona/status-strip + `session_env_setup` env vars). L2 = lifecycle context injection (UPS hints / hydrator / Stop reminders). L3 = voluntary skill invocation (`/verify` / `/design-rubric` / `/q` / `/pull` / `/learn`). All three are now named pyramid tiers; previously invisible.

### Lifecycle flowchart

New `## Lifecycle` section in ENFORCEMENT-MAP.md with a mermaid flowchart mapping SessionStart → UPS → PreToolUse → tool → PostToolUse → Stop → commit → PR → merge to firing tier classes. Pyramid says how invasive; lifecycle says when.

### Bug-fix scope (no CBA required)

Under `enforcement.md` §4.1, this is "bug fixes within an existing surface at the same position" — corrective edits to existing prose, not add/escalate. No CBA block.

### Fitness rubric authored before edits

Per `/design-rubric` discipline (eating dogfood on the gap filed in `aops-5193f975` / `aops-6a2e3432`): 6 falsifiers, 5 dimensions, 3 personas/scenarios authored on task `aops-98c7ce49` body BEFORE editing. Marsha /verify against rubric pre-commit returned PASS on all six falsifiers and five dimensions.

### Phase C defer-and-flag

Two residues found by grep that fall outside Phase A.5's two-file scope (per the Phase A pattern of defer-and-flag for wider sweeps):

1. `aops-core/skills/strategic-review/review-contexts/pr-framework.md:42` still uses "cost ladder" phrase. Phase A renamed cost-ladder→pyramid but this file wasn't swept.
2. `specs/enforcement/enforcement.md` §4 base/middle/tip table at lines 111-115 mixes pipeline L-numbers (L0-L11) with pyramid tier labels in the same cells. Conflation predates Phase A.5; cleaning requires either renaming pipeline labels to P0-P11 or splitting the table — out of this PR's surgical scope.

### Cross-references checked

- HEURISTICS.md P#65 — clean (no tier-number references, no "cost ladder").
- `aops-core/agents/rbg.md` — clean.
- `specs/GATES.md:17` — references "L0–L7 regulatory pyramid"; new pyramid is still L0–L7, cross-reference intact.

### Related filings (NOT closed by this PR)

The forensic /learn findings about the framework gap that allowed these defects to survive Phase A's `done` close remain open as separate PKB tasks pending GH filing:

- `aops-5193f975` — no AC-verification surface between merge_ready and done.
- `aops-6a2e3432` — judgment-laden AC routed without /design-rubric authoring.

These are process-gap issues distinct from this PR's content-bug fix. Do NOT close them with this PR.

### Refs

- Parent epic: `aops-1458eb7b`
- Phase A: `aops-2c087f74` (PR #1278)
- This task: `aops-98c7ce49`
