### PR TITLE
fix(hooks): stop harness worktrees from pushing to main

### DIFF
--- a/aops-core/hooks/session_env_setup.py
+++ b/aops-core/hooks/session_env_setup.py
@@ -233,6 +233,21 @@ def run_session_env_setup(ctx: HookContext, state: SessionState) -> GateResult |
             "If it is set in your shell profile it will still be picked up."
         )
 
+    # 6. Push-safety guard: harness-created worktrees (claude/<codename>) are
+    # branched off origin/main, so the new branch inherits origin/main as its
+    # upstream. With a global push.default=upstream, a bare `git push` then
+    # resolves to *main* — pushing agent work straight to the default branch and
+    # bypassing PR review. Polecat fixes this at worktree-creation time; this
+    # guard covers worktrees the framework did not create. See lib/git_safety.py.
+    try:
+        from lib.git_safety import ensure_worktree_push_safety
+
+        push_safety_msg = ensure_worktree_push_safety(ctx.cwd or os.getcwd())
+        if push_safety_msg:
+            messages.append(push_safety_msg)
+    except Exception as e:
+        print(f"WARNING: push-safety guard failed: {e}", file=sys.stderr)
+
     # 7. Ensure required CLIs (uv, gh, etc.) are accessible in PATH.
     # Centralised in lib/path_bootstrap — shared logic with ensure-path.sh.
     from lib.path_bootstrap import detect_path_additions

--- a/aops-core/lib/git_safety.py
+++ b/aops-core/lib/git_safety.py
@@ -92,6 +92,8 @@ def ensure_worktree_push_safety(cwd: Path | str) -> str | None:
         # we don't mutate the shared repo config; fall back to local repo config
         # when the worktreeConfig extension is not enabled (push.default=current
         # is a safe default for every branch, so repo-wide is acceptable).
+        # Enable worktree-specific config so we don't pollute the shared repo config
+        _git(["config", "extensions.worktreeConfig", "true"], cwd)
         pd = _git(["config", "--worktree", "push.default", "current"], cwd)
         if pd.returncode != 0:
             pd = _git(["config", "push.default", "current"], cwd)

--- a/aops-core/lib/git_safety.py
+++ b/aops-core/lib/git_safety.py
@@ -83,7 +83,7 @@ def ensure_worktree_push_safety(cwd: Path | str) -> str | None:
         if upstream.returncode != 0:
             return None  # no upstream configured — nothing dangerous
         upstream_ref = upstream.stdout.strip()
-        if upstream_ref not in _MAIN_UPSTREAMS:
+        if upstream_ref.split("/")[-1] not in _PROTECTED_BRANCHES:
             return None  # tracks its own branch (or something else safe)
 
         actions: list[str] = []

--- a/aops-core/lib/git_safety.py
+++ b/aops-core/lib/git_safety.py
@@ -1,0 +1,112 @@
+"""Git push-safety guard for agent worktrees.
+
+Problem class this closes
+-------------------------
+Harness-created worktrees (e.g. Claude Code ``claude/<codename>`` branches) are
+branched from ``refs/remotes/origin/main``. With git's ``branch.autoSetupMerge``,
+the new branch inherits ``origin/main`` as its upstream. Combined with a user's
+global ``push.default=upstream``, a bare ``git push`` then resolves to *main* —
+pushing the agent's work directly to the default branch and silently bypassing
+PR review (only "allowed" when the user has branch-protection bypass rights).
+
+Polecat worktrees avoid this by fixing tracking at creation time in
+``polecat/manager.py``. Harness worktrees never go through that path, so this
+guard runs at SessionStart (via ``hooks/session_env_setup.py``) and neutralises
+the footgun for ANY worktree, regardless of who created it.
+
+Design
+------
+The guard is intentionally network-free and idempotent (it must run on every
+SessionStart without side effects beyond the first remediation):
+
+1. ``push.default=current`` (worktree-local) — the primary guard. ``current``
+   pushes the checked-out branch to a *same-named* remote branch and never
+   consults the upstream, so a bare ``git push`` can never resolve to main even
+   if some later step re-sets the upstream.
+2. ``git branch --unset-upstream`` — removes the misleading main tracking so
+   ``git status`` / ``git pull`` stop referencing main, matching the polecat
+   invariant that a feature branch must not track main.
+
+It acts only on the dangerous condition (a non-main branch whose upstream is
+main), so the main checkout and correctly-tracked polecat worktrees are left
+untouched.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Upstream refs that mean "a bare push could hit the default branch".
+_MAIN_UPSTREAMS = {"origin/main", "main", "origin/master", "master"}
+# Branches whose own tracking we must never touch (they *should* track main).
+_PROTECTED_BRANCHES = {"main", "master"}
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def ensure_worktree_push_safety(cwd: Path | str) -> str | None:
+    """Make pushes from a main-tracking worktree safe.
+
+    Detects the condition where the current (non-main) branch's upstream is
+    main/origin/main — meaning a bare ``git push`` under ``push.default=upstream``
+    would target main — and remediates it (see module docstring).
+
+    Returns a concise status string when it remediates, else ``None``. Never
+    raises: any git failure degrades to ``None`` so SessionStart is never
+    blocked by this guard.
+    """
+    cwd = Path(cwd)
+    try:
+        inside = _git(["rev-parse", "--is-inside-work-tree"], cwd)
+        if inside.returncode != 0 or inside.stdout.strip() != "true":
+            return None
+
+        branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd).stdout.strip()
+        if not branch or branch == "HEAD":  # unborn or detached HEAD
+            return None
+        if branch in _PROTECTED_BRANCHES:
+            return None
+
+        upstream = _git(
+            ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+            cwd,
+        )
+        if upstream.returncode != 0:
+            return None  # no upstream configured — nothing dangerous
+        upstream_ref = upstream.stdout.strip()
+        if upstream_ref not in _MAIN_UPSTREAMS:
+            return None  # tracks its own branch (or something else safe)
+
+        actions: list[str] = []
+
+        # Primary guard: push.default=current. Prefer worktree-scoped config so
+        # we don't mutate the shared repo config; fall back to local repo config
+        # when the worktreeConfig extension is not enabled (push.default=current
+        # is a safe default for every branch, so repo-wide is acceptable).
+        pd = _git(["config", "--worktree", "push.default", "current"], cwd)
+        if pd.returncode != 0:
+            pd = _git(["config", "push.default", "current"], cwd)
+        if pd.returncode == 0:
+            actions.append("push.default=current")
+
+        # Secondary hygiene: drop the main-tracking upstream.
+        if _git(["branch", "--unset-upstream"], cwd).returncode == 0:
+            actions.append(f"unset upstream (was {upstream_ref})")
+
+        if not actions:
+            return None
+        return (
+            f"git push-safety: branch '{branch}' tracked '{upstream_ref}' — a bare "
+            f"push would have hit main. Applied: {', '.join(actions)}."
+        )
+    except Exception:
+        return None

--- a/tests/lib/test_git_safety.py
+++ b/tests/lib/test_git_safety.py
@@ -1,0 +1,158 @@
+"""Tests for lib/git_safety.ensure_worktree_push_safety.
+
+Reproduces the push-to-main footgun that hit a Claude Code harness worktree:
+a worktree branch whose upstream is ``origin/main``, which under the user's
+global ``push.default=upstream`` makes a bare ``git push`` resolve to *main*.
+The guard must neutralise this so pushes target the feature branch instead,
+while leaving correctly-configured branches (main itself, self-tracking
+feature branches) untouched.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[2].resolve()
+sys.path.insert(0, str(REPO_ROOT / "aops-core"))
+
+from lib.git_safety import ensure_worktree_push_safety  # noqa: E402
+
+
+def _git(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=check)
+
+
+def _upstream(repo: Path, branch: str = "HEAD") -> str | None:
+    r = _git(
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", f"{branch}@{{upstream}}"],
+        cwd=repo,
+        check=False,
+    )
+    return (r.stdout.strip() or None) if r.returncode == 0 else None
+
+
+@pytest.fixture()
+def origin(tmp_path: Path) -> Path:
+    """Bare repo acting as 'origin', seeded with a main branch."""
+    o = tmp_path / "origin.git"
+    _git(["init", "--bare", "-b", "main", str(o)], cwd=tmp_path)
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _git(["init", "-b", "main", str(seed)], cwd=tmp_path)
+    _git(["config", "user.email", "t@e.x"], cwd=seed)
+    _git(["config", "user.name", "T"], cwd=seed)
+    (seed / "README.md").write_text("seed\n")
+    _git(["add", "."], cwd=seed)
+    _git(["commit", "-m", "init"], cwd=seed)
+    _git(["remote", "add", "origin", str(o)], cwd=seed)
+    _git(["push", "-u", "origin", "main"], cwd=seed)
+    return o
+
+
+@pytest.fixture()
+def clone(tmp_path: Path, origin: Path) -> Path:
+    """Clone of origin with the user's dangerous global preference replicated.
+
+    ``push.default=upstream`` is exactly what turns a main-tracking upstream
+    into an accidental push to main; ``extensions.worktreeConfig`` lets the
+    guard write worktree-scoped config.
+    """
+    c = tmp_path / "clone"
+    _git(["clone", str(origin), str(c)], cwd=tmp_path)
+    _git(["config", "user.email", "t@e.x"], cwd=c)
+    _git(["config", "user.name", "T"], cwd=c)
+    _git(["config", "push.default", "upstream"], cwd=c)
+    _git(["config", "extensions.worktreeConfig", "true"], cwd=c)
+    return c
+
+
+def _worktree_tracking_main(clone: Path, tmp_path: Path, branch: str) -> Path:
+    """Create a worktree whose branch dangerously tracks origin/main."""
+    wt = tmp_path / branch.replace("/", "_")
+    _git(["worktree", "add", "-b", branch, str(wt), "main"], cwd=clone)
+    _git(["branch", "--set-upstream-to=origin/main", branch], cwd=wt)
+    assert _upstream(wt) == "origin/main", "precondition: branch must track origin/main"
+    return wt
+
+
+class TestEnsureWorktreePushSafety:
+    def test_neutralises_main_tracking(self, clone: Path, tmp_path: Path):
+        wt = _worktree_tracking_main(clone, tmp_path, "claude/feature-x")
+
+        msg = ensure_worktree_push_safety(wt)
+
+        assert msg is not None
+        assert "push.default=current" in msg
+        assert "claude/feature-x" in msg
+        # Upstream tracking removed.
+        assert _upstream(wt) is None
+        # push.default=current now in effect for this worktree.
+        assert _git(["config", "--get", "push.default"], cwd=wt).stdout.strip() == "current"
+
+    def test_bare_push_targets_feature_branch_not_main(
+        self, clone: Path, origin: Path, tmp_path: Path
+    ):
+        wt = _worktree_tracking_main(clone, tmp_path, "claude/feature-y")
+        ensure_worktree_push_safety(wt)
+
+        main_before = _git(["rev-parse", "refs/heads/main"], cwd=origin).stdout.strip()
+        (wt / "work.txt").write_text("work\n")
+        _git(["add", "work.txt"], cwd=wt)
+        _git(["commit", "-m", "work"], cwd=wt)
+
+        r = _git(["push"], cwd=wt, check=False)
+        assert r.returncode == 0, f"bare push failed: {r.stderr}"
+
+        main_after = _git(["rev-parse", "refs/heads/main"], cwd=origin).stdout.strip()
+        assert main_after == main_before, "origin/main must NOT advance"
+        feature_tip = _git(["rev-parse", "refs/heads/claude/feature-y"], cwd=origin).stdout.strip()
+        assert feature_tip == _git(["rev-parse", "HEAD"], cwd=wt).stdout.strip(), (
+            "the commit must land on the feature branch"
+        )
+
+    def test_without_guard_bare_push_hits_main(self, clone: Path, origin: Path, tmp_path: Path):
+        """Non-vacuous proof: without the guard, the bare push DOES hit main."""
+        wt = _worktree_tracking_main(clone, tmp_path, "claude/unfixed")
+        # Deliberately do NOT call the guard.
+        main_before = _git(["rev-parse", "refs/heads/main"], cwd=origin).stdout.strip()
+        (wt / "w.txt").write_text("w\n")
+        _git(["add", "w.txt"], cwd=wt)
+        _git(["commit", "-m", "w"], cwd=wt)
+
+        r = _git(["push"], cwd=wt, check=False)
+        assert r.returncode == 0, f"push failed: {r.stderr}"
+
+        main_after = _git(["rev-parse", "refs/heads/main"], cwd=origin).stdout.strip()
+        assert main_after != main_before, (
+            "expected the UNFIXED bare push to advance origin/main — if it didn't, "
+            "the test no longer reproduces the bug and the other tests are vacuous"
+        )
+
+    def test_main_branch_untouched(self, clone: Path):
+        # On main, tracking origin/main is correct; the guard must not touch it.
+        assert _upstream(clone) == "origin/main"
+        assert ensure_worktree_push_safety(clone) is None
+        assert _upstream(clone) == "origin/main"
+
+    def test_self_tracking_branch_untouched(self, clone: Path, tmp_path: Path):
+        wt = tmp_path / "selftrack"
+        _git(["worktree", "add", "-b", "claude/selftrack", str(wt), "main"], cwd=clone)
+        _git(["push", "-u", "origin", "claude/selftrack:claude/selftrack"], cwd=wt)
+        assert _upstream(wt) == "origin/claude/selftrack"
+
+        assert ensure_worktree_push_safety(wt) is None
+        assert _upstream(wt) == "origin/claude/selftrack"
+
+    def test_no_upstream_is_noop(self, clone: Path, tmp_path: Path):
+        wt = tmp_path / "noup"
+        _git(["worktree", "add", "-b", "claude/noup", str(wt), "main"], cwd=clone)
+        _git(["branch", "--unset-upstream", "claude/noup"], cwd=wt, check=False)
+        assert _upstream(wt) is None
+        assert ensure_worktree_push_safety(wt) is None
+
+    def test_non_repo_is_noop(self, tmp_path: Path):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        assert ensure_worktree_push_safety(plain) is None


### PR DESCRIPTION
## Summary
- Adds a SessionStart **push-safety guard** so harness-created worktrees can't accidentally push to `main`.
- New `aops-core/lib/git_safety.py::ensure_worktree_push_safety`: when a non-main branch tracks `origin/main`, it sets worktree-local `push.default=current` (pushes always target a same-named branch) and unsets the main-tracking upstream. Network-free, idempotent, no-op for `main` and self-tracking branches.
- Wired into `aops-core/hooks/session_env_setup.py` (runs every SessionStart).
- 7 unit tests in `tests/lib/test_git_safety.py`, including a non-vacuous proof that the bug reproduces **without** the guard.

## Why
Harness worktrees (`claude/<codename>`) are branched from `refs/remotes/origin/main`; with `branch.autoSetupMerge`, the new branch inherits `origin/main` as its upstream. Combined with a global `push.default=upstream`, a bare `git push` then resolves to `main` — pushing agent work straight to the default branch and bypassing PR review.

Polecat already fixes this at worktree-creation time (`polecat/manager.py`, see `tests/polecat/test_worktree_upstream.py`), but worktrees the framework does **not** create (the harness's own) were unprotected. This guard closes that gap for any worktree.

Motivated by an actual accidental push to `main` from this very worktree (the same footgun), which has since been remediated live by this guard.

## Test plan
- [x] `uv run pytest tests/lib/test_git_safety.py` — 7 passed
- [x] `uv run pytest tests/test_session_start.py` — 2 passed
- [x] Validated live: the guard neutralized this worktree's `origin/main` tracking (`push.default` is now `current`)
- [ ] Reviewer: confirm no-op behavior for the main checkout and self-tracking polecat branches

> Note: the unrelated test-assertion fix (`test_credential_isolation.py`, commit d3a9b3d5) is already on `main`, so this PR's diff is only the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)