### PR TITLE
feat(strategic-review): harden arch-fit lens — 🔴 REJECT verdict + earn-its-keep/No-Shitty-NLP corollary

### DIFF
--- a/aops-core/skills/strategic-review/SKILL.md
+++ b/aops-core/skills/strategic-review/SKILL.md
@@ -20,7 +20,7 @@ domain:
   - framework
   - quality-assurance
 allowed-tools: Task,Read
-version: 2.3.0
+version: 2.4.0
 permalink: skills-strategic-review
 ---
 
@@ -64,7 +64,7 @@ Invoke on a green, merge-ready PR before human approval:
 Agent(subagent_type="aops-core:pauli", prompt="[the lens text below + PR ref / diff + originating task]")
 ```
 
-This is the PENULTIMATE step before human approval. The lens reads deeply (diff + call sites + originating task + VISION + specs + PKB cross-repo links) but returns a thin surface — ~4 lines on a MERGE verdict, leading with a verdict glyph and a spot-check pointer, so Nic can make the call without re-reading the diff himself. The thin-surface cap is on what NIC READS; the lens still does the full analysis and records its full output on the PR (see the post + check actions in the prompt block).
+This is the PENULTIMATE step before human approval. The lens reads deeply (diff + call sites + originating task + VISION + specs + PKB cross-repo links) but returns a thin surface — leading with a verdict glyph, then ONE scannable line per applicable field plus a spot-check pointer, so Nic can make the call without re-reading the diff himself. The thin surface is one-line-per-field, NOT a fixed line count: an honest MERGE that owns its external-impact, persistence, and axiom-backstop lines runs ~7 lines and that is correct. The cap is on what NIC READS per line; the lens still does the full analysis and records its full output on the PR (see the post + check actions in the prompt block).
 
 **Not yet auto-wired into merge-prep — this is graduated enforcement (VISION).** It earns promotion to an always-on pipeline stage only after dogfooding proves it catches real wrong-place fixes without crying wolf. Promotion path (follow-up, not taken here): add it as a Pauli commission in `review-contexts/pr-code.md` / `pr-framework.md` so James runs it automatically on merge-ready PRs, and register `strategic-review/arch-fit` as an expected/required CI check so the PR cannot go green without it. **Do not take those steps until dogfooding earns it.** (Completing the check when the skill runs — below — is part of the skill now; _requiring_ the check is the promotion step.)
 
@@ -117,8 +117,23 @@ Failure patterns you are hunting (grounded in the vision):
   • Coordination / enforcement creep — adds a gate/hook/obligation/mechanism to control
     agent behaviour. The framework's #1 recurring failure (two resets). Default to
     suspicion; burden is on the PR.
-  • Component that doesn't earn its keep — new skill/script/flag/config surface for
-    something an existing component should carry, or that won't survive neglect.
+  • Component that doesn't earn its keep — new skill/script/flag/config/structure surface
+    for something an existing component should carry, or that won't survive neglect. The
+    burden is on the PR to name a consumer that genuinely NEEDS the new complexity; "a
+    counter / rollup / analytics pass COULD consume it" is NOT justification — a
+    hypothetical consumer whose need was never established earns nothing. NOR does a consumer
+    that already EXISTS and runs establish need by merely existing: a rollup that COUNTS or
+    DISPLAYS the signal, with nothing downstream DETERMINISTICALLY ACTING on it (no gate,
+    branch, brake, or depended-upon workflow keyed off the value), is observability for its
+    own sake — "it's live, tested, and wired to a dashboard" describes the CODE, not the need.
+    And the burden SCALES with the cost the PR imposes: obligating many producer surfaces to
+    emit a new structured signal is a high, spreading cost (coordination-creep-adjacent) that
+    a count-and-display consumer does not justify — and that one surface ALREADY emits the
+    token is not licence to extend the obligation to others; propagating an unjustified
+    pattern compounds it, never blesses it. Complexity or structure added without a
+    demonstrated benefit is ITSELF a defect, sufficient grounds to 🔴 REJECT on its own,
+    independent of correctness. Of every new field/token/enum ask: who actually reads it, what
+    do they DO differently because of it, and would a smart agent reading the prose have sufficed?
   • Entrenches what should shrink / fights the trajectory.
   • Procedure where philosophy belongs (skill/agent edits) — rigid mechanics/mode-routers
     where the principle is to state the goal and trust the agent.
@@ -140,7 +155,13 @@ container-local / host-temp-not-backed-up / durable — and STATE the final dura
 explicitly, or state plainly there isn't one. "Lands in the existing JSONL" is an automatic
 FAIL of this requirement: name the EXACT file, resolve any path helper to a real path, and
 check it against the backup/push policy. A non-backed-up intermediate is not automatically a
-blocker, but it MUST be surfaced and accepted, never assumed away.
+blocker, but it MUST be surfaced and accepted, never assumed away. CARVE-OUT: this fires for
+PRs that introduce or change a WRITE PATH or destination. A PR that only changes a VALUE
+flowing through an already-existing, already-traced path — no new persistence, no new file,
+no new destination (e.g. dropping a runtime fallback so a value is derived differently but
+lands in the same place) — does NOT owe a full trace: say "no new write path; existing
+persistence unchanged" in one line and move on. Don't manufacture a persistence concern
+where the PR creates none.
 
 AXIOM BACKSTOP (trust-but-verify of rbg). You are the penultimate gate before the human,
 so you backstop — not duplicate — the axiom stage. LOAD the canonical axiom set rbg
@@ -149,9 +170,14 @@ applies: `.agents/rules/AXIOMS.md` and its review checklist `.agents/rules/AXIOM
 axiom violation that rbg should have flagged slip past her? This is verification of her
 coverage of the CLASS, not a from-scratch re-review that re-litigates everything she
 already cleared — read the diff against the axioms looking for a missed violation, not for
-agreement on calls she made. If you find one: name the axiom (e.g. `categorical-imperative`,
+agreement on calls she made. HUNT WHAT THE PR GETS WRONG; never shop for an axiom it
+"satisfies" and cite that to bless the merge. Axiom COMPLIANCE is the absence of one kind of
+problem, never a positive reason to merge — "the PR correctly applies axiom X" is not a
+finding this backstop produces. Anti-rationalisation cuts BOTH ways: the backstop can talk
+itself INTO a merge (shopping for a blessing axiom) as easily as out of a hold.
+If you find one: name the axiom (e.g. `categorical-imperative`,
 an instance-specific carve-out where a general rule was required), treat it as a
-REDESIGN/HOLD-class signal in your verdict, AND flag it as a merge-prep/rbg PIPELINE GAP —
+REDESIGN/HOLD/REJECT-class signal in your verdict, AND flag it as a merge-prep/rbg PIPELINE GAP —
 the axiom stage let it through, which is itself worth surfacing. If rbg's coverage holds,
 say so in one line. Do NOT invent axioms or stretch a design smell into an axiom violation;
 a design smell with no axiom behind it belongs in the failure-pattern hunt above, not here.
@@ -168,6 +194,26 @@ ARCHITECTURE: structured data smuggled through an unstructured channel and re-pa
 exonerate it; the correct design carries the signal as structured data end-to-end, and if
 the structured channel isn't reachable that's an infrastructure gap to fix (halt + report),
 not a licence to parse prose.
+That axiom has a COROLLARY that cuts the OTHER way, and missing it is how this lens has
+already failed: we have smart agents — TRUST them for qualitative work, don't mechanise it.
+A verdict, a recommendation, any conclusion inseparable from its reasoning is QUALITATIVE;
+its real consumers read the prose and must. It stays qualitative even when its HEADLINE is a
+closed-set label (APPROVE / REVISE / PASS / FAIL): the label is a lossy handle on the
+conclusion, not the signal itself, and "it's one-of-N, so structuring it is fine" confuses
+the value's SHAPE with whether it is a judgment. What makes a value legitimately MECHANICAL is
+that a consumer DETERMINISTICALLY ACTS on it (branches, gates, brakes) — not that it happens
+to be one-of-N; a label nothing acts on, fed to a count-and-display rollup, is a qualitative
+judgment dressed as a metric. Adding a machine-countable token / enum / marker
+to a qualitative signal is the anti-pattern this axiom PROHIBITS — it is NOT an application
+of "don't dress prose as structure." When a PR mechanises a qualitative signal, do not bless
+it as "correctly structured"; fire the doesn't-earn-its-keep pattern instead — name the
+consumer that genuinely needs the enum, and if the only candidate is a hypothetical
+analytics rollup, that is complexity without demonstrated benefit → 🔴 REJECT. This routes to
+REJECT, not REDESIGN: the correct alternative to mechanising a qualitative signal is to leave
+it as prose the agent reads — i.e. BUILD NOTHING, keep the status quo — so the PR's own
+deliverable should not exist. Do NOT let a separable good edit bundled into the same PR
+launder this into REDESIGN. (A grep false-positive that "justifies" such a token is itself the
+argument for using an agent that reads context, not for the token.)
 
 DISCIPLINE:
   • A clean bill of health must be EARNED, not defaulted to. If the obvious reading shows
@@ -179,13 +225,22 @@ DISCIPLINE:
     and the alternative; Nic decides whether to override with a reason — not your call.
   • CORE-MECHANISM vs PERIPHERAL — do NOT launder a core-mechanism anti-pattern as
     "separable." Distinguish a PERIPHERAL tension (genuinely separable from the change's
-    value → may MERGE with the tension named) from an anti-pattern that IS the PR's CORE
-    MECHANISM (→ 🔁 REDESIGN or ⚠️ HOLD). Sharp test: if you removed the smell, would the
-    PR still do its job? If the smell IS the mechanism — removing it means redesigning the
-    feature — that is precisely the well-engineered-workaround-that-should-be-a-redesign
-    case this lens exists to catch: call REDESIGN. "Separable redesign, not a hold" must
-    NEVER be used to wave through a fundamentally-wrong approach. Do NOT anchor on "the code
-    is clean and passing" — clean+passing is exactly what hides this.
+    value → may MERGE, with the tension named — see "✅ MERGE (tension noted)") from an
+    anti-pattern that IS the PR's CORE MECHANISM (→ 🔁 REDESIGN, ⚠️ HOLD, or 🔴 REJECT).
+    Sharp test: if you removed the smell, would the PR still have a DELIVERABLE a consumer
+    needs? Ask it of the PR, NOT the system — the system keeps working without the PR (that's
+    the status quo it adds to); the question is whether the PR still has a REASON TO EXIST. If
+    the smell IS the mechanism but the goal still needs something built a different way or
+    elsewhere → call 🔁 REDESIGN (the well-engineered-workaround case this lens exists to
+    catch). But if removing the smell leaves the PR with NOTHING to deliver — the correct
+    alternative is to BUILD NOTHING (keep the prose, the existing field, the status quo a
+    smart agent already handles), the mechanism served a consumer that doesn't need it, or the
+    problem isn't real — there is no redesign to salvage; call 🔴 REJECT. Beware the BUNDLED
+    RESCUE: a separable, independently correct edit riding along in the same PR is NOT the
+    PR's deliverable — re-land it standalone, and judge the core by what the PR is actually
+    FOR. "Separable redesign, not a hold" must NEVER be used to wave through a
+    fundamentally-wrong approach. Do NOT anchor on "the code is clean and passing" —
+    clean+passing is exactly what hides this.
   • STEELMAN THE SECOND-BEST SITE. The alternative you name (in DISCIPLINE above and in
     OUTPUT step 2) must be the STRONGEST REAL place the logic could have lived — e.g. an
     existing processor that already handles the corpus and already persists durably — not a
@@ -194,30 +249,63 @@ DISCIPLINE:
     the perishable/better info the alternative would actually lose.
 
 OUTPUT — exactly what a final pre-merge human gate needs, no more.
-Lead with: ✅ MERGE / ⚠️ HOLD / 🔁 REDESIGN.
+Lead with ONE verdict:
+  ✅ MERGE — right place, right shape; approve.
+  ✅ MERGE (tension noted) — right place, but a genuinely SEPARABLE watch-point worth
+     recording (a dual-writer to retire later, a latent asymmetry) — not load-bearing enough
+     to block. Use this instead of a silent MERGE when there's an X to keep an eye on; still
+     merge-class. Name the X in the strategic-call line.
+  ⚠️ HOLD — sound in principle, but one thing must be resolved or confirmed before merge.
+  🔁 REDESIGN — right GOAL, wrong APPROACH: don't merge as-shaped; rework it (often
+     elsewhere) and resubmit. The well-engineered-workaround case.
+  🔴 REJECT — the change SHOULDN'T EXIST: close the PR. Either the goal isn't real, OR the
+     complexity earns nothing — no consumer genuinely needs it (complexity without
+     demonstrated benefit, a defect in itself). Deciding line vs REDESIGN: ask what the
+     CORRECT alternative is. If it is to BUILD the thing differently or elsewhere → REDESIGN.
+     If it is to BUILD NOTHING — keep the prose, the existing field, the status quo a smart
+     agent already handles — the PR's own deliverable should not exist → REJECT. "Rework as
+     prose / let the agent read it / the existing field already carries this" is REJECT
+     (nothing to build), not REDESIGN. And a separable, independently-correct edit BUNDLED in
+     the same PR does NOT rescue a reject-worthy core — re-land it standalone; judge the PR by
+     its PRIMARY deliverable, not by what rides alongside.
 Then only as much as the decision needs:
   1. What it actually does — one sentence, root-cause terms, not the PR's framing.
-  2. The strategic call — if MERGE: one line on why this location/shape is right, naming
-     the alternative you rejected. If HOLD/REDESIGN: THE one load-bearing concern as a
-     chain — what the PR does → the real root cause → where the fix should live / the
-     redesign → which vision principle is at stake. One concern; name any others in a
-     single trailing line.
+  2. The strategic call — if MERGE: one line on why this location/shape is right, naming the
+     alternative you rejected; if a consumer/parser FAILS OPEN (degrades to a safe default
+     rather than crashing or corrupting), name it — that property often bounds the risk and
+     earns the merge. If HOLD/REDESIGN: THE one load-bearing concern as a chain — what the
+     PR does → the real root cause → where the fix should live / the redesign → which vision
+     principle is at stake. If REJECT: name the unjustified cost — what complexity it adds
+     across how many surfaces and the consumer whose need is missing (or the non-problem it
+     targets) → say plainly it should be closed. One concern; name any others in a single
+     trailing line.
   3. External impact — one line: does merging imply concomitant changes in other
      repos/projects (name them), and are tasks already scheduled in the PKB for them
      (task-IDs) or not (flag it)? "None" if nothing connects outward.
-  3b. Persistence (only if the PR writes/persists data) — one line naming the final durable
-     destination as a concrete resolved path, or stating plainly there is none, with any
-     non-backed-up intermediate hop surfaced.
+  3b. Persistence (only if the PR introduces/changes a write path — see the carve-out) — one
+     line naming the final durable destination as a concrete resolved path, or stating
+     plainly there is none, with any non-backed-up intermediate hop surfaced.
   3c. Axiom backstop — one line: "rbg coverage OK" or "GAP — axiom <name> missed (pipeline
-     gap, REDESIGN/HOLD-class)".
+     gap, REDESIGN/HOLD/REJECT-class)".
+  3d. Issue-completeness (only if the PR claims to close/address a tracked issue) —
+     VERDICT-INDEPENDENT, one line: "discharges N of M fix-items from #X; remaining: <list>
+     (task scheduled? id / not)". Orthogonal to placement: a perfectly-placed change can
+     still close only part of its issue. Do NOT fold it into the counter-argument and do NOT
+     let it move the verdict — it's a completeness FYI, not a defect.
   4. Spot-check — the 1-2 file:line refs Nic can open to confirm the call in under a minute.
-  5. Confidence + counter-argument — high/medium/low with the reason (NOT a fake %), and
-     the strongest case AGAINST your own recommendation.
-HARD LIMITS: no correctness/test findings (out of scope). Axiom findings ONLY via the
-axiom-backstop line above — a single missed-violation flag, not a re-review dump. No
-multi-point critique dumps. If MERGE, the whole output is ~4 lines — Nic should be able to approve on your
-say-so without opening the diff, spot-check pointer there if he wants it. (The External-impact
-line is part of those ~4.)
+  5. Confidence + counter-argument — high/medium/low with the reason (NOT a fake %), and the
+     strongest case AGAINST your own recommendation.
+  6. Out-of-scope routing (only if you surfaced a correctness/test concern you can't judge) —
+     one line: name it and where it's been carried (marsha / a filed task), so a green
+     arch-fit + green CI can't let it slip. See the routing action below.
+HARD LIMITS: no correctness/test findings of your own (out of scope) — but a correctness
+wrinkle you CAN'T judge gets ROUTED (field 6), not buried. Axiom findings ONLY via the
+axiom-backstop line — a single missed-violation flag, not a re-review dump. No multi-point
+critique dumps WITHIN a field. The thin surface is ONE LINE PER FIELD, not a fixed total:
+omit fields that don't apply, but never amputate a mandatory field (external-impact,
+axiom-backstop) to hit an arbitrary "~4 lines" — an honest MERGE runs ~7 lines and that is
+correct. The cap is Nic's READING EFFORT per line (one scannable line, lead with the verdict,
+spot-check pointer for anything he wants to open himself), not total honesty.
 
 AFTER the verdict — this lens is the penultimate step before human approval, so record it
 on the PR itself:
@@ -225,10 +313,19 @@ on the PR itself:
     real names, emails, private filesystem paths, stakeholder identities. Keep it about the
     architecture, not the people.
   • COMPLETE the named check `strategic-review/arch-fit` on the PR head SHA, conclusion
-    matching the verdict: ✅ MERGE → success; ⚠️ HOLD / 🔁 REDESIGN → failure (or neutral).
-    Mechanism: GitHub Checks API / commit status on the PR head SHA — e.g.
-    `gh api repos/{owner}/{repo}/check-runs -f name=strategic-review/arch-fit -f head_sha=<sha> -f status=completed -f conclusion=<success|failure|neutral>`
-    (or a commit status). This requires a token with checks/statuses write on the repo.
+    matching the verdict: ✅ MERGE → success; ⚠️ HOLD / 🔁 REDESIGN / 🔴 REJECT → failure
+    (or neutral). PRIMARY mechanism = a COMMIT STATUS, which works under the bot token:
+    `gh api -X POST repos/{owner}/{repo}/statuses/<sha> -f context=strategic-review/arch-fit -f state=<success|failure> -f description=<short>`
+    Do NOT lead with the Checks API (`/check-runs`): under the bot PAT it 403s EVERY run
+    ("must authenticate via a GitHub App"), so reaching for it first just burns a guaranteed
+    failure. The check-run form becomes available only once this lens is promoted behind a
+    GitHub App at pipeline-wiring time — upgrade then, use commit status now.
+  • ROUTE any out-of-scope concern you surfaced. If reconstructing the change surfaced a
+    CORRECTNESS or test-coverage wrinkle you can't judge (out of this lens's lane), your
+    green arch-fit status + green CI must NOT be allowed to imply it's clear — CI may not
+    cover it. Carry it: state it (output field 6) AND hand it to a correctness reviewer —
+    file a follow-up task or @-mention marsha in the PR comment — so a real concern can't
+    slip between "arch-fit OK" and "CI green."
   • The PR therefore may NOT be fully green until AFTER this skill runs — the
     `strategic-review/arch-fit` check is pending until then. That is expected.
 ```


### PR DESCRIPTION
## What & why

Applies the accumulated **architectural-fit lens refinement batch** to `aops-core/skills/strategic-review/SKILL.md` (the `--arch-fit` lens, run by pauli). Branched off post-#1562 main.

The 6-cycle dogfood (#1545 / #1553 / #1559 / #1547 / #1549 / #1550, task `aops-8c7f7b88`) banked a set of fixes; its **headline finding** was that the lens *rationalised a ✅ MERGE on reject-worthy #1549* — a PR that mechanised a qualitative reviewer verdict onto a parseable token to feed an analytics rollup whose need was never established (complexity without a demonstrated consumer). Nic closed #1549. The lens literally had no verdict that could express "scrap it," and its axiom-backstop talked itself *into* the merge by shopping for an axiom the PR "satisfied."

## Changes (v2.3.0 → v2.4.0)

- **🔴 REJECT verdict**, distinct from 🔁 REDESIGN. Deciding line: what is the correct alternative? *Build something differently / elsewhere* → REDESIGN; *build nothing — keep the prose, the existing field, the status quo a smart agent already handles* → REJECT. A separable good edit **bundled** into the same PR does **not** launder a reject-worthy core into REDESIGN — re-land it standalone; judge the PR by its primary deliverable.
- **Earn-its-keep, sharpened.** Burden on the PR to name a consumer that genuinely *needs* the new complexity. A rollup that only **counts/displays** a signal establishes no need — "live, tested, wired to a dashboard" describes the *code*, not the need. The burden **scales with the obligation's cost** (obligating many producer surfaces is high). A value is legitimately **mechanical** only when a consumer **deterministically acts** on it (branch/gate/brake), not because it is one-of-N.
- **No-Shitty-NLP corollary + anti-rationalisation, both directions.** The axiom-backstop must *hunt what the PR gets wrong*, never shop for a blessing axiom (it can talk into a MERGE as easily as out of a HOLD). Mechanising a qualitative signal is the anti-pattern the axiom prohibits — not an application of *don't-dress-prose-as-structure*. A signal stays qualitative even when its headline is a closed-set label.
- **Six more banked fixes:** `✅ MERGE (tension noted)` tier; a verdict-independent **issue-completeness** field; **out-of-scope correctness routing** (carry a wrinkle you can't judge to marsha, don't let green-arch-fit + green-CI bury it); a **persistence-trace carve-out** for value-only edits + a consumer **fail-open** note; **reconcile the thin-surface cap** (one line per field — an honest MERGE runs ~7 lines, don't amputate a mandatory field to hit "~4"); **commit-status as the PRIMARY check mechanism** (the Checks API 403s every run under the bot token — needs a GitHub App).

## Validation

Re-ran the refined lens through **pauli, blinded** — recorded verdicts (`mem-231996ac`) and prior arch-fit PR comments explicitly set aside, primary artifacts only:

| PR | Target | Result | Notes |
|----|--------|--------|-------|
| #1549 | 🔴 REJECT | 🔴 **REJECT** | Reached on the merits: traced the consumer chain → nothing deterministically acts on the verdict token → observability for its own sake → cost across 5 surfaces → BUILD NOTHING. Correctly treated the bundled R6 edit as a separable rescue. |
| #1559 | ✅ MERGE | ✅ **MERGE** | No cry-wolf: carve-out applied, issue-completeness stayed verdict-independent, the deterministic-action language did not over-fire (no producer obligation added). |

**Honest note on the journey:** the batch did not land #1549 in one shot. Blinded, the first draft *undershot* to 🔁 REDESIGN; a second draft flipped to ✅ MERGE when the reviewer argued "the rollup is a *live* consumer." Closing those two specific escape hatches — the **deterministic-action test**, the **cost-scaled burden**, and **label-shape ≠ judgment** — got it to REJECT. Those principles are general (they'd apply to any "add a structured signal to feed analytics" PR), not tuned to #1549. The verdict on #1549 remains a genuinely hard call that hinges on the "does anything *act* on it?" judgment; the lens now makes that test prominent and hard to skip, but does not pretend to mechanically guarantee the call.

## Scope / non-goals

- Still a **manually-invoked** lens; merge-prep is not auto-wired (graduated enforcement — promotion remains a documented follow-up).
- This is the **backstop**; the cheap primary catch belongs upstream at `/planner` (`aops-8d4a2e14`).

Task: `aops-ddf0779f` · epic `epic-7b06cc0e` · knowledge `mem-231996ac`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
