### PR TITLE
fix(strategic-review): point arch-fit lens at the real vision/specs locations

### DIFF
--- a/aops-core/skills/strategic-review/SKILL.md
+++ b/aops-core/skills/strategic-review/SKILL.md
@@ -20,7 +20,7 @@ domain:
   - framework
   - quality-assurance
 allowed-tools: Task,Read
-version: 2.4.0
+version: 2.4.1
 permalink: skills-strategic-review
 ---
 
@@ -64,7 +64,7 @@ Invoke on a green, merge-ready PR before human approval:
 Agent(subagent_type="aops-core:pauli", prompt="[the lens text below + PR ref / diff + originating task]")
 ```
 
-This is the PENULTIMATE step before human approval. The lens reads deeply (diff + call sites + originating task + VISION + specs + PKB cross-repo links) but returns a thin surface — leading with a verdict glyph, then ONE scannable line per applicable field plus a spot-check pointer, so Nic can make the call without re-reading the diff himself. The thin surface is one-line-per-field, NOT a fixed line count: an honest MERGE that owns its external-impact, persistence, and axiom-backstop lines runs ~7 lines and that is correct. The cap is on what NIC READS per line; the lens still does the full analysis and records its full output on the PR (see the post + check actions in the prompt block).
+This is the PENULTIMATE step before human approval. The lens reads deeply (diff + call sites + originating task + vision note + specs + PKB cross-repo links) but returns a thin surface — leading with a verdict glyph, then ONE scannable line per applicable field plus a spot-check pointer, so Nic can make the call without re-reading the diff himself. The thin surface is one-line-per-field, NOT a fixed line count: an honest MERGE that owns its external-impact, persistence, and axiom-backstop lines runs ~7 lines and that is correct. The cap is on what NIC READS per line; the lens still does the full analysis and records its full output on the PR (see the post + check actions in the prompt block).
 
 **Not yet auto-wired into merge-prep — this is graduated enforcement (VISION).** It earns promotion to an always-on pipeline stage only after dogfooding proves it catches real wrong-place fixes without crying wolf. Promotion path (follow-up, not taken here): add it as a Pauli commission in `review-contexts/pr-code.md` / `pr-framework.md` so James runs it automatically on merge-ready PRs, and register `strategic-review/arch-fit` as an expected/required CI check so the PR cannot go green without it. **Do not take those steps until dogfooding earns it.** (Completing the check when the skill runs — below — is part of the skill now; _requiring_ the check is the promotion step.)
 
@@ -88,12 +88,13 @@ solves, where that problem originates, and whether here is where it should be so
 RECONSTRUCT, DON'T ACCEPT. Do not take the PR description's account of the problem.
 Read the originating task/issue, the changed files, AND their call sites and the
 abstraction they belong to — you cannot judge "should be elsewhere" without reading
-what elsewhere is. Strategic context lives in: projects/aops/vision (VISION) and the
-relevant projects/aops/specs/ doc, plus the linked task. NOT STATUS.md or any
-operational snapshot.
+what elsewhere is. Strategic context lives in: the PKB vision note `[[vision]]`
+(permalink `aops-vision`; fetch with get_document) for framework intent and design
+philosophy, and the relevant doc in the repo-root `specs/` tree (map: `specs/INDEX.md`)
+for the canonical spec, plus the linked task. NOT STATUS.md or any operational snapshot.
 
 SPEC GROUNDING. Ground the change against the canonical spec — normally the relevant
-projects/aops/specs/ doc. But for a taxonomy / SSoT edit, the edited file may itself BE
+doc in the repo-root `specs/` tree. But for a taxonomy / SSoT edit, the edited file may itself BE
 the canonical spec: there is no external doc to match against. In that case the grounding
 check becomes "is the SSoT edit internally coherent, and fully propagated to every
 consumer?" — not "does it match a specs/ doc."


### PR DESCRIPTION
## Problem

The `--arch-fit` lens in `aops-core/skills/strategic-review/SKILL.md` told pauli:

> Strategic context lives in: **projects/aops/vision (VISION)** and the relevant **projects/aops/specs/** doc

But `projects/aops/vision` **does not exist** as a file anywhere in academicOps (`git ls-files | grep -i vision` finds only unrelated files; `docs/VISION.md` is absent on `main`). The lens cited it ~4× as a grounding source, so every arch-fit run pointed the reviewer at a missing path. Two independent pauli runs flagged this during the PR #1563 dogfood — one noted the principles it needed (framework-shrink, no-coordination-creep) weren't at that path.

## Where the vision actually lives

The canonical vision is **real but lives in the PKB, not the repo**: the note **`[[vision]]`** (permalink `aops-vision`, title *"Automation Framework Vision"*), consolidated from the former `docs/VISION.md` — recorded in `specs/INDEX.md` line 21 (`academicOps/docs/VISION.md → [[vision]]`). It contains exactly the principles the lens invokes:

| Lens failure-pattern | Vision source |
|---|---|
| "framework should SHRINK when external tools improve" | Design Philosophy #7 |
| "Coordination/enforcement creep — #1 recurring failure (two resets)" | *What We've Learned* + Non-Goal "Coordination infrastructure that costs more than it saves" |
| "state the goal and trust the agent" | Design Philosophy #2, #10 |
| "doesn't earn its keep / won't survive neglect" | Design Philosophy #8 |

pauli already calls `get_document` inside this lens (for cross-repo impact), so the note is directly reachable — no new tooling needed.

`.agents/CORE.md` already references it correctly as `[[vision|brain/projects/aops/vision]]` — a resolvable PKB wikilink whose `brain/` prefix shows it lives in the brain/PKB repo. The lens had simply dropped the `brain/` prefix, turning a PKB path into a non-existent repo path.

## Spec pointer also corrected

The lens cited `projects/aops/specs/` for "the canonical spec." That directory exists but holds **only the `daily/` subsystem**. The canonical spec tree (CONSTRAINTS, SURFACES, ENFORCEMENT-MAP, `enforcement/enforcement.md`, …) lives at the **repo-root `specs/`**, mapped by `specs/INDEX.md` — and that's the tree `AXIOMS.md` itself cross-references. Repointed both grounding citations to repo-root `specs/`.

## Changes (1 file, +7/−6)

- VISION pointer → `[[vision]]` (permalink `aops-vision`, fetch with `get_document`)
- spec pointer (2×) → repo-root `specs/` tree (map: `specs/INDEX.md`)
- prose echo on the "reads deeply (… VISION + specs …)" line → "vision note"
- patch version bump `2.4.0 → 2.4.1`

Conceptual references that don't name a path ("grounded in the vision", "which vision principle is at stake", the graduated-enforcement "(VISION)" tag) are **left as-is** — they now resolve correctly against the fixed pointer.

## Scope

Pre-existing issue (predates #1563). Scoped strictly to the grounding-pointer fix; no behavioural change to the lens logic.

## Verification

- `git grep 'projects/aops/vision'` / `'projects/aops/specs/'` in SKILL.md → none remaining
- `projects/aops/specs/` confirmed to exist (holds `daily/`); repo-root `specs/` confirmed as the canonical tree
- PKB `get_document('vision')` resolves to permalink `aops-vision`
- pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
