### PR TITLE
fix: correctly translate mcp tool names for gemini

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -801,6 +801,12 @@ def translate_tool_calls(text: str, platform: str) -> str:
     if platform == "gemini":
         # Replace Claude plugin path variable with Gemini equivalent
         text = text.replace("${CLAUDE_PLUGIN_ROOT}", "${extensionPath}")
+
+        text = re.sub(
+            r"mcp__[a-zA-Z0-9_-]+__[a-zA-Z0-9_-]*",
+            lambda m: claude_mcp_to_gemini(m.group(0)),
+            text,
+        )
     elif platform == "antigravity":
         # agy (Antigravity 2.0) is Claude-tool-compatible: agents ship with Claude
         # tool names (no frontmatter/body transformation). It uses Claude Code hook


### PR DESCRIPTION
Fixes a bug where Claude plugin-namespaced `mcp__` tool references within markdown bodies were not being globally transformed into Gemini's `mcp_` underscore format, causing validation failures in agent schemas. Moved the `re.sub` logic for `claude_mcp_to_gemini` into the `gemini` platform scope inside `scripts/build.py:translate_tool_calls`.

---
*PR created automatically by Jules for task [4761726645788432904](https://jules.google.com/task/4761726645788432904) started by @nicsuzor*