### PR TITLE
Fix Gemini tool name translation bug

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -801,14 +801,6 @@ def translate_tool_calls(text: str, platform: str) -> str:
     if platform == "gemini":
         # Replace Claude plugin path variable with Gemini equivalent
         text = text.replace("${CLAUDE_PLUGIN_ROOT}", "${extensionPath}")
-    elif platform == "antigravity":
-        # agy (Antigravity 2.0) is Claude-tool-compatible: agents ship with Claude
-        # tool names (no frontmatter/body transformation). It uses Claude Code hook
-        # event names (PreToolUse etc.) but its own plugin root path. ${extensionPath}
-        # is not defined in agy; hooks hardcode this same path, so we match it here.
-        text = text.replace(
-            "${CLAUDE_PLUGIN_ROOT}", "$HOME/.gemini/antigravity-cli/plugins/aops-core"
-        )
 
         text = re.sub(
             r"mcp__[a-zA-Z0-9_-]+__[a-zA-Z0-9_-]*",
@@ -824,6 +816,15 @@ def translate_tool_calls(text: str, platform: str) -> str:
         text = text.replace("Task() tool", "activate_skill() tool")
         text = text.replace("`Task(`", "`activate_skill(`")
         text = text.replace("`Skill(`", "`activate_skill(`")
+
+    elif platform == "antigravity":
+        # agy (Antigravity 2.0) is Claude-tool-compatible: agents ship with Claude
+        # tool names (no frontmatter/body transformation). It uses Claude Code hook
+        # event names (PreToolUse etc.) but its own plugin root path. ${extensionPath}
+        # is not defined in agy; hooks hardcode this same path, so we match it here.
+        text = text.replace(
+            "${CLAUDE_PLUGIN_ROOT}", "$HOME/.gemini/antigravity-cli/plugins/aops-core"
+        )
 
     return text
 


### PR DESCRIPTION
Fixes a regression where Gemini tool translations incorrectly skipped execution due to the `antigravity` condition accidentally terminating the Gemini check flow.

---
*PR created automatically by Jules for task [6054209832980672838](https://jules.google.com/task/6054209832980672838) started by @nicsuzor*