### PR TITLE
feat(aops-ts): add opt-in Tailscale bring-up plugin

### DIFF
--- a/aops-core/BUILD.md
+++ b/aops-core/BUILD.md
@@ -43,6 +43,8 @@ There is no separate dist repo. `nicsuzor/academicOps` is both the source of tru
 
 `aops-tools` is a separate, lightweight plugin: skills only, no hooks/agents/MCP. Built from `aops-tools/` with its own `templates/aops-tools.*` manifests.
 
+`aops-ts` is a separate, **opt-in** plugin: a single `SessionStart` hook (no skills/agents/MCP) that runs `tailscale up` so tailnet-only services (e.g. the PKB MCP at `*.ts.net`) resolve in remote/cloud sessions. It is intentionally standalone — a self-contained bash hook with no router/Python/uv dependency — so it can be enabled independently of aops-core, and joining the tailnet stays an explicit choice. Built from `aops-ts/` by `build_aops_ts` (Claude only → `dist/aops-ts-claude`) with the `templates/aops-ts.plugin.json` manifest; registered in `templates/marketplace.json` with source `./dist/aops-ts-claude`. Tailscale itself is installed by the environment's setup script, not this plugin (the authkey only exists at session runtime, so bring-up must be a hook, not setup).
+
 ## The cowork build variant
 
 `aops-cowork` is a separate plugin built from the same `aops-core/` source tree. It is Claude-shaped (same `.claude-plugin/plugin.json` + `.mcp.json` layout) but ships **four** cowork-specific differences:

--- a/aops-ts/README.md
+++ b/aops-ts/README.md
@@ -1,0 +1,53 @@
+# aops-ts
+
+Opt-in Tailscale bring-up for academicOps remote/cloud sessions.
+
+`aops-ts` is a single-purpose plugin: a `SessionStart` hook that runs
+`tailscale up` so tailnet-only services — most importantly the **PKB MCP server**
+at `*.ts.net` — resolve inside a remote session (e.g. Claude Code on the web).
+
+It is deliberately **separate from `aops-core`** so joining the tailnet is an
+explicit choice. Installing `aops-core` never brings up Tailscale on its own;
+you must add `aops-ts` to an environment that should be on the tailnet.
+
+## Why a hook (and not the setup script)
+
+The authkey (`TS_AUTHKEY`) is injected at **session runtime**, not at container
+init. So bring-up cannot live in the environment's setup script — it must run at
+`SessionStart`, which is exactly what this hook does. User-level
+(`~/.claude/settings.json`) hooks do not run in cloud sessions, so the bring-up
+must ship as a repo/plugin hook.
+
+## Prerequisites
+
+1. **Tailscale installed.** This plugin does **not** install Tailscale (that
+   needs root + `curl | sh` at container init). Add the install to your
+   environment's setup script:
+
+   ```bash
+   command -v tailscale >/dev/null 2>&1 || curl -fsSL https://tailscale.com/install.sh | sh
+   ```
+
+2. **`TS_AUTHKEY` available at session time.** Provision it as an environment
+   variable for the remote environment.
+
+3. **`aops-ts` enabled.** Install the plugin in environments that should join
+   the tailnet:
+
+   ```bash
+   claude plugin install aops-ts@academicOps
+   ```
+
+## Behaviour
+
+The hook no-ops (exit 0) unless **all** of these hold:
+
+- `CLAUDE_CODE_REMOTE=true` (only acts in remote/cloud sessions)
+- `TS_AUTHKEY` is set
+- `tailscale` is on `PATH`
+
+When it acts, it starts `tailscaled` if needed, then runs `tailscale up` with
+`--accept-dns=true` (required for MagicDNS resolution of `*.ts.net` hosts). It
+always exits 0 — a Tailscale failure must never block session start. Diagnostics
+go to stderr (SessionStart stdout is injected into the model context, so it is
+kept empty).

--- a/aops-ts/hooks/hooks.json
+++ b/aops-ts/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/tailscale-up.sh\"",
+            "timeout": 30000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/aops-ts/hooks/tailscale-up.sh
+++ b/aops-ts/hooks/tailscale-up.sh
@@ -24,29 +24,46 @@ command -v tailscale >/dev/null 2>&1 || {
   exit 0
 }
 
+# Some remote environments run the session as a non-root user; tailscale(d) then
+# needs sudo. Use passwordless sudo when available, else run direct (works as root).
+SUDO=""
+if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+  SUDO="sudo -n"
+fi
+
+# Log to a user-writable dir: the shell performs the redirect (as the session
+# user), so /var/log would fail with "permission denied" for non-root even under sudo.
+LOG="${TMPDIR:-/tmp}/tailscaled.log"
+
 # Already connected? Nothing to do (daemon + state persist within a container).
-if tailscale status >/dev/null 2>&1; then
-  echo "[aops-ts] tailscale already up as $(tailscale ip -4 2>/dev/null | head -1)"
+if $SUDO tailscale status >/dev/null 2>&1; then
+  echo "[aops-ts] tailscale already up as $($SUDO tailscale ip -4 2>/dev/null | head -1)"
   exit 0
 fi
 
 # Daemon is per-process (the container cache keeps files, not processes) — start it if absent.
 if ! pgrep -x tailscaled >/dev/null 2>&1; then
-  mkdir -p /var/lib/tailscale /var/run/tailscale
-  setsid tailscaled \
+  $SUDO mkdir -p /var/lib/tailscale /var/run/tailscale
+  $SUDO setsid tailscaled \
     --state=/var/lib/tailscale/tailscaled.state \
     --socket=/var/run/tailscale/tailscaled.sock \
     --tun=tailscale0 \
-    >/var/log/tailscaled.log 2>&1 </dev/null & disown || true
-  for _ in $(seq 1 30); do [ -S /var/run/tailscale/tailscaled.sock ] && break; sleep 0.5; done
+    >"$LOG" 2>&1 </dev/null & disown || true
+  # Wait for the socket, but fail fast if the daemon dies (missing tun, fatal error)
+  # instead of blocking session start for the full 15s.
+  for _ in $(seq 1 30); do
+    [ -S /var/run/tailscale/tailscaled.sock ] && break
+    pgrep -x tailscaled >/dev/null 2>&1 || break
+    sleep 0.5
+  done
 fi
 
-if tailscale up --authkey="${TS_AUTHKEY}" \
+if $SUDO tailscale up --authkey="${TS_AUTHKEY}" \
      --hostname="claude-web-${HOSTNAME:-sandbox}" \
      --accept-routes --accept-dns=true; then
-  echo "[aops-ts] tailscale up as $(tailscale ip -4 2>/dev/null | head -1)"
+  echo "[aops-ts] tailscale up as $($SUDO tailscale ip -4 2>/dev/null | head -1)"
 else
-  echo "[aops-ts] 'tailscale up' failed; see /var/log/tailscaled.log"
+  echo "[aops-ts] 'tailscale up' failed; see $LOG"
 fi
 
 exit 0

--- a/aops-ts/hooks/tailscale-up.sh
+++ b/aops-ts/hooks/tailscale-up.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# aops-ts SessionStart hook — bring Tailscale up in remote/cloud sessions so
+# tailnet services (e.g. the PKB MCP at *.ts.net) resolve.
+#
+# Opt-in by design: this lives in the standalone `aops-ts` plugin, NOT aops-core.
+# Enable it only in environments that should join the tailnet.
+#
+# Division of labour:
+#   - The environment's setup/init script INSTALLS tailscale (needs root +
+#     curl|sh, and runs at container init — where TS_AUTHKEY is NOT yet present).
+#   - This hook brings the tailnet UP at session start, where TS_AUTHKEY IS
+#     injected. It installs nothing.
+#
+# No-ops (exit 0) unless: remote session, TS_AUTHKEY set, tailscale installed.
+# It always exits 0 — a tailscale hiccup must never block SessionStart.
+
+set -uo pipefail
+exec 1>&2   # SessionStart stdout is injected into the model context — keep it empty
+
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
+[ -n "${TS_AUTHKEY:-}" ] || { echo "[aops-ts] TS_AUTHKEY not set; skipping tailscale bring-up."; exit 0; }
+command -v tailscale >/dev/null 2>&1 || {
+  echo "[aops-ts] tailscale not installed — add the install line to your environment setup script; skipping."
+  exit 0
+}
+
+# Already connected? Nothing to do (daemon + state persist within a container).
+if tailscale status >/dev/null 2>&1; then
+  echo "[aops-ts] tailscale already up as $(tailscale ip -4 2>/dev/null | head -1)"
+  exit 0
+fi
+
+# Daemon is per-process (the container cache keeps files, not processes) — start it if absent.
+if ! pgrep -x tailscaled >/dev/null 2>&1; then
+  mkdir -p /var/lib/tailscale /var/run/tailscale
+  setsid tailscaled \
+    --state=/var/lib/tailscale/tailscaled.state \
+    --socket=/var/run/tailscale/tailscaled.sock \
+    --tun=tailscale0 \
+    >/var/log/tailscaled.log 2>&1 </dev/null & disown || true
+  for _ in $(seq 1 30); do [ -S /var/run/tailscale/tailscaled.sock ] && break; sleep 0.5; done
+fi
+
+if tailscale up --authkey="${TS_AUTHKEY}" \
+     --hostname="claude-web-${HOSTNAME:-sandbox}" \
+     --accept-routes --accept-dns=true; then
+  echo "[aops-ts] tailscale up as $(tailscale ip -4 2>/dev/null | head -1)"
+else
+  echo "[aops-ts] 'tailscale up' failed; see /var/log/tailscaled.log"
+fi
+
+exit 0

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1587,6 +1587,74 @@ def build_aops_extras(
     print(f"✓ Built {plugin_name} ({platform})")
 
 
+def build_aops_ts(
+    aops_root: Path,
+    dist_root: Path,
+    platform: str = "claude",
+    version: str = "0.1.0",
+):
+    """Build the aops-ts extension for a specific platform.
+
+    aops-ts is a tiny, opt-in package: a single SessionStart hook that brings
+    Tailscale up in remote/cloud sessions so tailnet services (e.g. the PKB MCP
+    at *.ts.net) resolve. It is intentionally standalone — a self-contained bash
+    hook with no router/Python/uv dependency — so it can be enabled on its own,
+    independent of aops-core. Only the Claude platform is built; the tailnet
+    bring-up targets Claude Code on the web.
+    """
+    print(f"Building aops-ts for {platform} (v{version})...")
+    plugin_name = "aops-ts"
+    src_dir = aops_root / plugin_name
+
+    if not src_dir.exists():
+        print(f"  ⚠️  {src_dir} not found, skipping aops-ts build")
+        return
+
+    dist_dir = dist_root / f"aops-ts-{platform}"
+    content_dir = dist_dir
+
+    if dist_dir.exists():
+        shutil.rmtree(dist_dir)
+    dist_dir.mkdir(parents=True)
+
+    # Copy the hook payload (and docs) verbatim. Hooks are auto-discovered by
+    # Claude Code from hooks/hooks.json — no manifest declaration needed.
+    items_to_copy = ["hooks", "README.md"]
+    for item in items_to_copy:
+        src = src_dir / item
+        if src.exists():
+            safe_copy(src, content_dir / item)
+
+    # Claude: copy plugin.json with version injection + marketplace-field hygiene.
+    if platform == "claude":
+        src_plugin_json = aops_root / "templates" / f"{plugin_name}.plugin.json"
+        dist_plugin_dir = dist_dir / ".claude-plugin"
+        dist_plugin_json = dist_plugin_dir / "plugin.json"
+        if src_plugin_json.exists():
+            try:
+                dist_plugin_dir.mkdir(parents=True, exist_ok=True)
+                manifest = json.loads(src_plugin_json.read_text())
+                manifest["version"] = version
+
+                # Hygiene: strip marketplace-only and deprecated fields that
+                # otherwise trip CC's "Unrecognized keys" install validation.
+                manifest.pop("source", None)
+                manifest.pop("category", None)
+                manifest.pop("userConfig", None)
+
+                with open(dist_plugin_json, "w") as f:
+                    json.dump(manifest, f, indent=2)
+                    f.write("\n")
+                print(f"  ✓ Updated and hygienically copied plugin.json -> {dist_plugin_json}")
+            except Exception as e:
+                print(f"Error processing plugin.json: {e}", file=sys.stderr)
+        else:
+            print(f"Error: {src_plugin_json} not found.", file=sys.stderr)
+            sys.exit(1)
+
+    print(f"✓ Built {plugin_name} ({platform})")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Build script for AcademicOps Gemini extensions.")
     parser.add_argument("--version", action="store_true", help="Print detected version and exit")
@@ -1654,6 +1722,9 @@ def main():
     # Build aops-extras (replaceable technology-specific skills package)
     build_aops_extras(aops_root, dist_root, "gemini", version)
     build_aops_extras(aops_root, dist_root, "claude", version)
+
+    # Build aops-ts (opt-in Tailscale bring-up hook — Claude/web only)
+    build_aops_ts(aops_root, dist_root, "claude", version)
 
     # Build components (Antigravity)
     build_aops_core(aops_root, dist_root, aca_data_path, "antigravity", version)

--- a/templates/aops-ts.plugin.json
+++ b/templates/aops-ts.plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "aops-ts",
+  "version": "0.3.42",
+  "description": "AcademicOps Tailscale bring-up - opt-in SessionStart hook that joins the tailnet in remote/cloud sessions so tailnet services (e.g. the PKB MCP) resolve",
+  "author": {
+    "name": "Nicolas Suzor"
+  },
+  "license": "MIT",
+  "keywords": [
+    "academicOps",
+    "tailscale",
+    "hooks",
+    "remote"
+  ]
+}

--- a/templates/marketplace.json
+++ b/templates/marketplace.json
@@ -46,6 +46,16 @@
       },
       "source": "./dist/aops-cowork",
       "category": "productivity"
+    },
+    {
+      "name": "aops-ts",
+      "description": "AcademicOps Tailscale bring-up - opt-in SessionStart hook that joins the tailnet in remote/cloud sessions so tailnet services (e.g. the PKB MCP) resolve",
+      "version": "__VERSION__",
+      "author": {
+        "name": "Nicolas Suzor"
+      },
+      "source": "./dist/aops-ts-claude",
+      "category": "productivity"
     }
   ]
 }


### PR DESCRIPTION
## What

A new **standalone, opt-in** plugin `aops-ts` whose single `SessionStart` hook runs `tailscale up` in remote/cloud sessions, so tailnet-only services — most importantly the **PKB MCP server at `*.ts.net`** — resolve.

## Why

The PKB MCP lives on the tailnet (`PKB_MCP_URL=http://services-new.stoat-musical.ts.net:8025/mcp/`). Without Tailscale up, PKB never connects in a cloud session. The previous approach (an init-script-written project hook) failed for two structural reasons confirmed against the live environment:

- **No project dir at init time.** `CLAUDE_PROJECT_DIR` is unset and `PWD=/home/user` (the parent, not the repo) when the setup script runs, so the hook landed in `/home/user/.claude/` — a directory Claude never reads.
- **User-scoped hooks don't run on the web.** Per the docs, `~/.claude/settings.json` hooks are ignored in cloud sessions.
- **The setup script can't do the bring-up.** `TS_AUTHKEY` is injected only at session runtime, not container init — so bring-up *must* be a `SessionStart` hook. (Tailscale *install* stays in the env setup script.)

A plugin hook is the right home: aops-core's plugin hooks demonstrably fire in cloud sessions, and a separate plugin keeps joining the tailnet an explicit choice rather than something every aops-core install does.

## Design

- **Separate from aops-core** — opt-in; enable only where the tailnet is wanted (`claude plugin install aops-ts@academicOps`).
- **Self-contained bash hook** — no router/Python/uv dependency, so it installs independently.
- **Claude/web only** — no gemini/antigravity/cowork variants.
- **Safe no-op** — exits 0 unless `CLAUDE_CODE_REMOTE=true`, `TS_AUTHKEY` set, and `tailscale` installed; always exits 0 so a Tailscale failure never blocks session start. stdout kept empty (SessionStart stdout is injected into model context); diagnostics to stderr.

## Changes

- `aops-ts/hooks/hooks.json` + `aops-ts/hooks/tailscale-up.sh` (executable) — the hook
- `aops-ts/README.md` — opt-in docs + prerequisites
- `templates/aops-ts.plugin.json` — Claude manifest
- `templates/marketplace.json` — registers `aops-ts` (source `./dist/aops-ts-claude`)
- `scripts/build.py` — `build_aops_ts` (Claude only), wired into `main()`
- `aops-core/BUILD.md` — documents the new package

## Verification

- `build_aops_ts` run in isolation → produces `dist/aops-ts-claude/` with version injected, `source`/`category` stripped, hooks copied with exec bit preserved, `SessionStart` event present.
- `bash -n` on the hook, JSON-valid manifests, `python -m py_compile` + `ruff check` on `build.py` all pass.
- **Not yet verified:** a full `tailscale up --authkey` join to completion in a live session (the bring-up `tailscaled` start was validated manually; the authenticated join was not run). The logic mirrors the working manual bring-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y248BkDtRV6AJH7FajVJ62

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y248BkDtRV6AJH7FajVJ62)_