### PR TITLE
fix(daily): enforce correct placement of audit-complete sentinel

### DIFF
--- a/aops-core/lib/gates/custom_actions.py
+++ b/aops-core/lib/gates/custom_actions.py
@@ -161,6 +161,20 @@ def create_audit_file(
                 or "",  # allow-fallback: empty scope when no skill / scope file absent
             },
         )
+
+        # Coverage sentinel: must be the last line of the rendered file so that
+        # a truncated read is detectable. The rbg auditor requires this via
+        # `tail -3` (aops-e4e90f31, #1976).
+        if content and gate == "enforcer":
+            import re
+            # Extract turn count from session_context if possible, fallback to ?
+            turns = re.findall(r"#### Turn (\d+)", session_context)
+            turn_num = turns[-1] if turns else "?"
+
+            # Use rstrip to ensure no trailing newlines from the template
+            # push the sentinel out of the `tail -3` window
+            content = content.rstrip() + f"\n\n<!-- audit-complete: {turn_num} turns -->\n"
+
     except (KeyError, ValueError, FileNotFoundError) as e:
         render_errors.append(f"{gate}.context: {e}")
         try:

--- a/aops-core/lib/gates/custom_actions.py
+++ b/aops-core/lib/gates/custom_actions.py
@@ -167,6 +167,7 @@ def create_audit_file(
         # `tail -3` (aops-e4e90f31, #1976).
         if content and gate == "enforcer":
             import re
+
             # Extract turn count from session_context if possible, fallback to ?
             turns = re.findall(r"#### Turn (\d+)", session_context)
             turn_num = turns[-1] if turns else "?"

--- a/aops-core/lib/session_reader.py
+++ b/aops-core/lib/session_reader.py
@@ -611,12 +611,8 @@ def build_audit_session_context(
     if not lines:
         return "(No meaningful session content extracted)"
 
-    # Coverage sentinel: must be the last content in the file so that a
-    # truncated read (e.g. Read tool default 2000-line limit) is detectable.
-    # The enforcer-instruction requires RBG to verify this line before
-    # certifying; if it is absent, the read was incomplete (aops-e4e90f31).
-    lines.append("")
-    lines.append(f"<!-- audit-complete: {turn_num} turns -->")
+    # The coverage sentinel (audit-complete) is appended by `custom_actions.py`
+    # to ensure it is the genuine final line of the rendered file (#1976).
 
     return "\n".join(lines)
 

--- a/tests/lib/test_session_reader.py
+++ b/tests/lib/test_session_reader.py
@@ -915,6 +915,7 @@ class TestBuildAuditSessionContext:
 
     def test_audit_complete_sentinel_not_present(self, tmp_path):
         from lib.session_reader import build_audit_session_context
+
         jsonl_path = tmp_path / "session.jsonl"
         entries_data = [_create_user_entry("Do some work", 0), _create_assistant_entry(1)]
         _write_jsonl(jsonl_path, entries_data)

--- a/tests/lib/test_session_reader.py
+++ b/tests/lib/test_session_reader.py
@@ -922,8 +922,14 @@ class TestBuildAuditSessionContext:
         result = build_audit_session_context(str(jsonl_path))
         assert "<!-- audit-complete:" not in result
 
-    def test_audit_complete_sentinel_includes_turn_count(self, tmp_path):
-        """Audit sentinel reports turn count so RBG can detect suspicious mismatches."""
+    def test_session_reader_does_not_add_sentinel(self, tmp_path):
+        """build_audit_session_context does not emit the audit sentinel.
+
+        The sentinel is added by custom_actions.py after template rendering so
+        it lands as the absolute last line of the file (#1976).  Session-reader
+        output must not contain it — the downstream appender is the single
+        point of injection.
+        """
         from lib.session_reader import SessionProcessor, build_audit_session_context
 
         jsonl_path = tmp_path / "three-turns.jsonl"
@@ -943,14 +949,15 @@ class TestBuildAuditSessionContext:
         )
         result = build_audit_session_context(str(jsonl_path), entries=entries)
 
-        # Sentinel must include the count of turns processed
+        # Sentinel is injected by custom_actions.py, not here.
         assert "<!-- audit-complete: 3 turns -->" not in result
 
     def test_max_turns_window_keeps_only_last_n_turns(self, tmp_path):
         """max_turns windows to the last n turns (aops-5bc65f76 n+2 cadence window).
 
         With max_turns set, older turns are dropped but every SHOWN turn keeps
-        full detail. The audit-complete sentinel reports the windowed count.
+        full detail.  The audit-complete sentinel is appended by custom_actions.py
+        after rendering and is not present in session-reader output.
         """
         from lib.session_reader import SessionProcessor, build_audit_session_context
 
@@ -974,7 +981,7 @@ class TestBuildAuditSessionContext:
             assert f"Turn {i} request" not in result, f"Turn {i} should be windowed out"
         for i in range(7, 11):
             assert f"Turn {i} request" in result, f"Turn {i} should be in window"
-        # Sentinel reports the windowed turn count, not the full session count.
+        # Sentinel is appended by custom_actions.py, not session_reader.
         assert "<!-- audit-complete: 4 turns -->" not in result
 
     def test_max_turns_none_renders_all_turns(self, tmp_path):

--- a/tests/lib/test_session_reader.py
+++ b/tests/lib/test_session_reader.py
@@ -913,28 +913,13 @@ class TestBuildAuditSessionContext:
         for i in range(1, 9):
             assert f"Turn {i} request" in result
 
-    def test_audit_complete_sentinel_present(self, tmp_path):
-        """Audit output ends with <!-- audit-complete --> sentinel.
-
-        This sentinel lets RBG verify it read the full file before certifying.
-        A truncated read (e.g. Read tool 2000-line default) would miss the
-        sentinel, triggering a COVERAGE_INCOMPLETE response (aops-e4e90f31).
-        """
+    def test_audit_complete_sentinel_not_present(self, tmp_path):
         from lib.session_reader import build_audit_session_context
-
         jsonl_path = tmp_path / "session.jsonl"
-        entries_data = [
-            _create_user_entry("Do some work", 0),
-            _create_assistant_entry(1),
-        ]
+        entries_data = [_create_user_entry("Do some work", 0), _create_assistant_entry(1)]
         _write_jsonl(jsonl_path, entries_data)
-
         result = build_audit_session_context(str(jsonl_path))
-
-        assert "<!-- audit-complete:" in result
-        # Sentinel must be at or near the very end of the output
-        last_200 = result[-200:]
-        assert "<!-- audit-complete:" in last_200
+        assert "<!-- audit-complete:" not in result
 
     def test_audit_complete_sentinel_includes_turn_count(self, tmp_path):
         """Audit sentinel reports turn count so RBG can detect suspicious mismatches."""
@@ -958,7 +943,7 @@ class TestBuildAuditSessionContext:
         result = build_audit_session_context(str(jsonl_path), entries=entries)
 
         # Sentinel must include the count of turns processed
-        assert "<!-- audit-complete: 3 turns -->" in result
+        assert "<!-- audit-complete: 3 turns -->" not in result
 
     def test_max_turns_window_keeps_only_last_n_turns(self, tmp_path):
         """max_turns windows to the last n turns (aops-5bc65f76 n+2 cadence window).
@@ -989,7 +974,7 @@ class TestBuildAuditSessionContext:
         for i in range(7, 11):
             assert f"Turn {i} request" in result, f"Turn {i} should be in window"
         # Sentinel reports the windowed turn count, not the full session count.
-        assert "<!-- audit-complete: 4 turns -->" in result
+        assert "<!-- audit-complete: 4 turns -->" not in result
 
     def test_max_turns_none_renders_all_turns(self, tmp_path):
         """max_turns=None (default) renders the whole session — no windowing."""
@@ -1011,7 +996,7 @@ class TestBuildAuditSessionContext:
         result = build_audit_session_context(str(jsonl_path), entries=entries, max_turns=None)
         for i in range(1, 7):
             assert f"Turn {i} request" in result
-        assert "<!-- audit-complete: 6 turns -->" in result
+        assert "<!-- audit-complete: 6 turns -->" not in result
 
     def test_window_larger_than_session_keeps_all_detail(self, tmp_path):
         """A window wider than the session shows every turn at full detail.


### PR DESCRIPTION
The rbg auditor relies on `tail -3` to find the `<!-- audit-complete -->` sentinel at the end of the `enforcer-context.md` file to verify the read was complete. However, the sentinel was being appended to the `session_context` string *before* being interpolated into the template. Because the template contains additional text (e.g., `## Your Assessment`) after the `{session_context}` placeholder, the sentinel was buried mid-file. This led to a deterministic, false-positive `COVERAGE_INCOMPLETE` error every time.

This PR fixes this by moving the sentinel injection to the very end of the file-writing process in `custom_actions.py`. The sentinel is now appended to the finalized `content` string, ensuring it is the absolute last line of the file, allowing `tail -3` to find it correctly. The turn count is preserved by extracting it from the `session_context` via regex. Tests in `test_session_reader.py` have been updated accordingly.

---
*PR created automatically by Jules for task [18278607515688155102](https://jules.google.com/task/18278607515688155102) started by @nicsuzor*