### PR TITLE
fix(mcp): tolerate trailing slash in PKB_MCP_URL

### DIFF
--- a/aops-core/scripts/run-mcp.sh
+++ b/aops-core/scripts/run-mcp.sh
@@ -29,6 +29,14 @@ if [[ -z "$PKB_MCP_URL" ]]; then
     exit 1
 fi
 
+# Normalise the URL: strip trailing slashes. The streamable-HTTP endpoint is
+# served at `…/mcp` (no trailing slash); a `…/mcp/` value 404s and the proxy
+# fails to connect. Container/env configs routinely carry a trailing slash, so
+# tolerate it here rather than depending on every supplier getting it exact.
+while [[ "$PKB_MCP_URL" == */ ]]; do
+    PKB_MCP_URL="${PKB_MCP_URL%/}"
+done
+
 if ! command -v uvx &> /dev/null; then
     echo "CRITICAL: 'uvx' not found on PATH after probing common locations." >&2
     echo "Install uv: https://docs.astral.sh/uv/getting-started/installation/" >&2


### PR DESCRIPTION
## Summary

Both PKB MCP servers (`aops-core:pkb` and `aops-cowork:pkb`) were failing to connect in this environment. Root cause: the configured `PKB_MCP_URL` carries a **trailing slash** (`…/mcp/`), but the PKB streamable-HTTP endpoint is served at `…/mcp` (no slash).

- `POST …/mcp/` → **404**
- `POST …/mcp`  → **200** (valid MCP `initialize` response; backend is `pkb` v0.3.72, 39 tools)

So `uvx fastmcp run "$PKB_MCP_URL"` starts the stdio proxy but can never reach the backend, and the client reports *Failed to connect*.

## Fix

Normalise `PKB_MCP_URL` in the launcher by stripping any trailing slash(es) before invoking `uvx fastmcp run`. This tolerates the trailing slash that container/env configs routinely carry, rather than depending on every supplier (Claude `userConfig`, Gemini env block, dev shells) producing the exact form. The `aops-cowork` build vendors this same script, so the one change covers both plugins.

## Verification

- Reproduced the failure: launcher with `…/mcp/` → proxy starts but health check fails.
- With the patch, a full MCP `initialize` handshake through the launcher succeeds even when given the trailing-slash URL.
- Patched the live plugin cache in the running container and confirmed `claude mcp list` now reports both servers **√ Connected**.

Everything else in the environment checked out healthy: git/branch, the agent proxy, the GitHub MCP server, `uvx`/`uv`, and the PKB backend itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmcpQmTAKr7BXB8rVmvyEv)_