### PR TITLE
fix: complete enforcer→rbg rename, restore green Pytest on dev

### DIFF
--- a/aops-core/hooks/router.py
+++ b/aops-core/hooks/router.py
@@ -950,7 +950,7 @@ class HookRouter:
             # enforcement: a non-blocking nudge can be disregarded by the model
             # (mem-4ab6cc0b), so block-mode gates keep decision="block".
             spec = client_spec.channel_spec("claude", "Stop")
-            agent_ctx_without_block = bool(spec and spec.agent_without_block)
+            agent_ctx_without_block = bool(spec and spec.agent_context_without_block)
 
             ctx_inj = result.context_injection
             sys_msg = result.system_message

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -302,9 +302,10 @@ def get_project_version(aops_root: Path) -> str:
 
 
 # The shipped aops-core hook deps are declared in the TRACKED source file
-# aops-core/pyproject.toml (epic-267fe017). The build reads that file and stamps
-# the version (+ trims hooks for cowork); there is no longer an inline pyproject
-# string literal here that could drift from the real file.
+# templates/aops-core.pyproject.toml (epic-267fe017). The build reads that file
+# and stamps the version; there is no longer an inline pyproject string literal
+# here that could drift from the real file. Not called for platform=="cowork" —
+# that build ships no pyproject.toml/uv.lock at all (see build_aops_core).
 AOPS_CORE_PYPROJECT_PLACEHOLDER_VERSION = "0.0.0"
 
 # Matches the `version = "..."` line under [project] (placeholder in source).
@@ -316,20 +317,16 @@ def generate_aops_core_pyproject(
 ) -> str:
     """Return the shipped pyproject.toml content with the build version stamped in.
 
-    Each platform reads its own tracked source manifest — the single source of
-    truth for that surface's shipped runtime deps — and substitutes the
-    placeholder version with the real build version.
+    All platforms that ship a pyproject.toml (``claude`` / ``gemini`` /
+    ``antigravity``) read the same tracked source manifest,
+    ``templates/aops-core.pyproject.toml`` (ships ``lib`` + ``hooks``), and get
+    the placeholder version substituted with the real build version.
 
-    - ``claude`` / ``gemini`` / ``antigravity`` read ``aops-core/pyproject.toml``
-      (ships ``lib`` + ``hooks``).
-    - ``cowork`` reads ``aops-cowork/pyproject.toml``. aops-cowork is a REAL
-      composed package (see build_aops_core): it carries its own committed
-      manifest, already lib-only because the cowork build ships NO hooks (the
-      shared aops-core hook stack serves the Cowork surface when aops-core is
-      installed from the dist marketplace — task aops-04075740 / mem-fe29111a).
-      Listing a ``hooks`` package that isn't on disk would break
-      ``uv sync --frozen`` at runtime, so the committed cowork manifest declares
-      ``packages = ["lib"]`` directly rather than having it trimmed here.
+    Not called for ``cowork`` — that build ships NO hooks (the shared aops-core
+    hook stack serves the Cowork surface when aops-core is installed from the
+    dist marketplace — task aops-04075740 / mem-fe29111a) and has no Python
+    deps of its own, so ``build_aops_core`` skips generating a pyproject.toml
+    (and the matching uv.lock) for it entirely rather than trimming one down.
     """
     if aops_root is None:
         aops_root = SCRIPT_DIR.parent
@@ -857,19 +854,26 @@ def build_aops_core(
 
     # 1b. Stamp the tracked source pyproject (the in-tree SSoT for shipped deps)
     # with the build version and write it into the dist payload, then lock against
-    # that stamped copy so pyproject.toml and uv.lock ship in lockstep. The source
-    # is per-platform: aops-core/pyproject.toml (epic-267fe017) for claude/gemini/
-    # agy, and the real aops-cowork/pyproject.toml (lib-only) for cowork. uv.lock
+    # that stamped copy so pyproject.toml and uv.lock ship in lockstep. `uv.lock`
     # is NOT tracked — it is generated here per-platform. `uv sync --frozen` at
     # runtime then installs exactly what the manifest declared, no drift.
-    pyproject_source = "templates/aops-core.pyproject.toml"
-    pyproject_content = generate_aops_core_pyproject(version, platform, aops_root)
-    pyproject_path = content_dir / "pyproject.toml"
-    pyproject_path.write_text(pyproject_content)
-    print(f"  ✓ Stamped pyproject.toml (v{version}) from {pyproject_source}")
+    #
+    # The cowork build ships neither a pyproject.toml nor a uv.lock: it has no
+    # hooks/ (see the skip above) and no Python dependencies of its own — the
+    # aops-core install co-located in the Cowork marketplace supplies the shared
+    # hook stack and its dependencies. Declaring a manifest here would just be
+    # dead packaging metadata for a package with nothing to install.
+    if platform != "cowork":
+        pyproject_source = "templates/aops-core.pyproject.toml"
+        pyproject_content = generate_aops_core_pyproject(version, platform, aops_root)
+        pyproject_path = content_dir / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+        print(f"  ✓ Stamped pyproject.toml (v{version}) from {pyproject_source}")
 
-    subprocess.run(["uv", "lock"], cwd=content_dir, check=True)
-    print("  ✓ Regenerated uv.lock from pyproject.toml")
+        subprocess.run(["uv", "lock"], cwd=content_dir, check=True)
+        print("  ✓ Regenerated uv.lock from pyproject.toml")
+    else:
+        print("  - Skipped pyproject.toml/uv.lock for cowork (no deps of its own)")
 
     # 1b. Copy root-level scripts
     scripts_src = aops_root / "scripts"

--- a/tests/hooks/conftest.py
+++ b/tests/hooks/conftest.py
@@ -19,7 +19,7 @@ def _deterministic_gate_modes(monkeypatch):
         monkeypatch,
         handover="warn",
         qa="block",
-        enforcer="block",
+        rbg="block",
         hydration="off",
     )
     reinit_gates_with_defaults()

--- a/tests/hooks/gate_helpers.py
+++ b/tests/hooks/gate_helpers.py
@@ -105,11 +105,11 @@ def set_gate_modes(
     *,
     handover: str = "warn",
     qa: str = "block",
-    enforcer: str = "block",
+    rbg: str = "block",
     hydration: str = "off",
     ida: str = "off",
     rbg_review: str = "off",
-    enforcer_threshold: int = 50,
+    rbg_threshold: int = 50,
 ) -> None:
     """Stamp the requested gate modes onto the environment.
 
@@ -120,11 +120,11 @@ def set_gate_modes(
     """
     monkeypatch.setenv("HANDOVER_GATE_MODE", handover)
     monkeypatch.setenv("QA_GATE_MODE", qa)
-    monkeypatch.setenv("ENFORCER_GATE_MODE", enforcer)
+    monkeypatch.setenv("RBG_GATE_MODE", rbg)
     monkeypatch.setenv("HYDRATION_GATE_MODE", hydration)
     monkeypatch.setenv("IDA_GATE_MODE", ida)
     monkeypatch.setenv("RBG_REVIEW_GATE_MODE", rbg_review)
-    monkeypatch.setenv("ENFORCER_TOOL_CALL_THRESHOLD", str(enforcer_threshold))
+    monkeypatch.setenv("RBG_TOOL_CALL_THRESHOLD", str(rbg_threshold))
 
 
 def make_session_state(scenario: dict) -> SessionState:
@@ -168,17 +168,17 @@ def make_context(scenario: dict) -> HookContext:
 def make_gate_trigger_state(gate_name: str) -> SessionState:
     """Create a SessionState that causes the named gate's policy to fire.
 
-    - enforcer: ops_since_open at threshold
+    - rbg: ops_since_open at threshold
     - qa / handover / ida: gate CLOSED so Stop-event policy fires
 
     For the handover gate, session_did_work is set to True so the policy
     condition (which exempts read-only sessions) is satisfied (aops-16a15a05).
     """
     state = SessionState.create("test-gate-mode", client_type="claude")
-    if gate_name == "enforcer":
-        from hooks.gate_config import ENFORCER_TOOL_CALL_THRESHOLD
+    if gate_name == "rbg":
+        from hooks.gate_config import RBG_TOOL_CALL_THRESHOLD
 
-        state.gates["enforcer"].ops_since_open = ENFORCER_TOOL_CALL_THRESHOLD
+        state.gates["rbg"].ops_since_open = RBG_TOOL_CALL_THRESHOLD
     elif gate_name in ("qa", "handover", "ida"):
         if gate_name not in state.gates:
             state.gates[gate_name] = GateState(status=GateStatus.CLOSED)
@@ -196,10 +196,10 @@ def make_gate_trigger_state(gate_name: str) -> SessionState:
 def make_gate_trigger_context(gate_name: str) -> HookContext:
     """Create a HookContext that triggers the named gate's policy.
 
-    - enforcer: PreToolUse on Agent (spawn tool, not excluded)
+    - rbg: PreToolUse on Agent (spawn tool, not excluded)
     - qa / handover / ida: Stop event
     """
-    if gate_name == "enforcer":
+    if gate_name == "rbg":
         return HookContext(
             session_id="test-gate-mode",
             client_type="claude",

--- a/tests/hooks/test_agy_protojson_contract.py
+++ b/tests/hooks/test_agy_protojson_contract.py
@@ -74,11 +74,11 @@ def _seed_enforcer_deny(monkeypatch, state_dir, session_id: str) -> None:
     compliance DENY — the safety-critical verdict the agy harness silently drops.
     """
     monkeypatch.setenv("AOPS_SESSION_STATE_DIR", str(state_dir))
-    monkeypatch.setenv("ENFORCER_GATE_MODE", "block")
-    monkeypatch.setenv("ENFORCER_TOOL_CALL_THRESHOLD", "50")
+    monkeypatch.setenv("RBG_GATE_MODE", "block")
+    monkeypatch.setenv("RBG_TOOL_CALL_THRESHOLD", "50")
     state = SessionState.create(session_id, client_type="agy")
-    state.gates["enforcer"].status = GateStatus.OPEN
-    state.gates["enforcer"].ops_since_open = 100
+    state.gates["rbg"].status = GateStatus.OPEN
+    state.gates["rbg"].ops_since_open = 100
     state.save()
 
 

--- a/tests/hooks/test_agy_worker_gate_posture.py
+++ b/tests/hooks/test_agy_worker_gate_posture.py
@@ -63,11 +63,11 @@ def _run_agy_router(
 def _seed_enforcer_deny(monkeypatch, state_dir: Path, session_id: str) -> None:
     """Seed on-disk state so a PreToolUse on session_id produces an enforcer DENY."""
     monkeypatch.setenv("AOPS_SESSION_STATE_DIR", str(state_dir))
-    monkeypatch.setenv("ENFORCER_GATE_MODE", "block")
-    monkeypatch.setenv("ENFORCER_TOOL_CALL_THRESHOLD", "50")
+    monkeypatch.setenv("RBG_GATE_MODE", "block")
+    monkeypatch.setenv("RBG_TOOL_CALL_THRESHOLD", "50")
     state = SessionState.create(session_id, client_type="agy")
-    state.gates["enforcer"].status = GateStatus.OPEN
-    state.gates["enforcer"].ops_since_open = 100
+    state.gates["rbg"].status = GateStatus.OPEN
+    state.gates["rbg"].ops_since_open = 100
     state.save()
 
 
@@ -100,7 +100,7 @@ def test_pretooluse_allow_when_agy_client_set(monkeypatch, tmp_path):
         "PreToolUse",
         extra_env={
             "AOPS_SESSION_STATE_DIR": str(tmp_path),
-            "ENFORCER_GATE_MODE": "block",
+            "RBG_GATE_MODE": "block",
             "AOPS_AGY_CLIENT": "1",  # polecat-launched agy worker
         },
     )
@@ -128,7 +128,7 @@ def test_pretooluse_deny_without_agy_client(monkeypatch, tmp_path):
         "PreToolUse",
         extra_env={
             "AOPS_SESSION_STATE_DIR": str(tmp_path),
-            "ENFORCER_GATE_MODE": "block",
+            "RBG_GATE_MODE": "block",
             # AOPS_AGY_CLIENT intentionally absent — normal (non-worker) agy
         },
     )
@@ -146,11 +146,11 @@ def test_warn_mode_enforcer_allows_without_agy_client(monkeypatch, tmp_path):
     """
     sid = "agy-warn-enforcer-allow"
     monkeypatch.setenv("AOPS_SESSION_STATE_DIR", str(tmp_path))
-    monkeypatch.setenv("ENFORCER_GATE_MODE", "warn")
-    monkeypatch.setenv("ENFORCER_TOOL_CALL_THRESHOLD", "50")
+    monkeypatch.setenv("RBG_GATE_MODE", "warn")
+    monkeypatch.setenv("RBG_TOOL_CALL_THRESHOLD", "50")
     state = SessionState.create(sid, client_type="agy")
-    state.gates["enforcer"].status = GateStatus.OPEN
-    state.gates["enforcer"].ops_since_open = 100
+    state.gates["rbg"].status = GateStatus.OPEN
+    state.gates["rbg"].ops_since_open = 100
     state.save()
 
     output, stderr = _run_agy_router(
@@ -158,7 +158,7 @@ def test_warn_mode_enforcer_allows_without_agy_client(monkeypatch, tmp_path):
         "PreToolUse",
         extra_env={
             "AOPS_SESSION_STATE_DIR": str(tmp_path),
-            "ENFORCER_GATE_MODE": "warn",
+            "RBG_GATE_MODE": "warn",
         },
     )
 

--- a/tests/hooks/test_custodiet_cluster.py
+++ b/tests/hooks/test_custodiet_cluster.py
@@ -63,10 +63,10 @@ def _reinit_gates(monkeypatch, tmp_path):
 
     monkeypatch.setenv("HANDOVER_GATE_MODE", "warn")
     monkeypatch.setenv("QA_GATE_MODE", "block")
-    monkeypatch.setenv("ENFORCER_GATE_MODE", "block")
+    monkeypatch.setenv("RBG_GATE_MODE", "block")
     monkeypatch.setenv("HYDRATION_GATE_MODE", "off")
     monkeypatch.setenv("IDA_GATE_MODE", "warn")
-    monkeypatch.setenv("ENFORCER_TOOL_CALL_THRESHOLD", "50")
+    monkeypatch.setenv("RBG_TOOL_CALL_THRESHOLD", "50")
 
     if "hooks.gate_config" in sys.modules:
         # sys.modules["hooks.gate_config"]._reset_gate_mode_cache()
@@ -171,11 +171,11 @@ class TestMidEditDeferral:
     """Enforcer must not block when agent has an in-progress todo item."""
 
     def _state_at_threshold(self, has_in_progress: bool = False) -> SessionState:
-        from hooks.gate_config import ENFORCER_TOOL_CALL_THRESHOLD
+        from hooks.gate_config import RBG_TOOL_CALL_THRESHOLD
 
         state = _make_state()
-        state.gates["enforcer"].ops_since_open = ENFORCER_TOOL_CALL_THRESHOLD
-        state.gates["enforcer"].metrics["has_in_progress_todo"] = has_in_progress
+        state.gates["rbg"].ops_since_open = RBG_TOOL_CALL_THRESHOLD
+        state.gates["rbg"].metrics["has_in_progress_todo"] = has_in_progress
         return state
 
     def test_blocks_without_in_progress_todo(self, router):
@@ -218,12 +218,12 @@ class TestMidEditDeferral:
 
         router._dispatch_gates(ctx, state)
 
-        assert state.gates["enforcer"].metrics.get("has_in_progress_todo") is True
+        assert state.gates["rbg"].metrics.get("has_in_progress_todo") is True
 
     def test_todowrite_trigger_clears_flag_when_no_in_progress(self, router):
         """PostToolUse on TodoWrite with all completed clears the metric."""
         state = _make_state()
-        state.gates["enforcer"].metrics["has_in_progress_todo"] = True
+        state.gates["rbg"].metrics["has_in_progress_todo"] = True
 
         todos = [
             {"content": "Step 1", "status": "completed"},
@@ -237,7 +237,7 @@ class TestMidEditDeferral:
 
         router._dispatch_gates(ctx, state)
 
-        assert state.gates["enforcer"].metrics.get("has_in_progress_todo") is False
+        assert state.gates["rbg"].metrics.get("has_in_progress_todo") is False
 
 
 # ===========================================================================
@@ -507,12 +507,12 @@ class TestAuditWindowAndDirective:
     is prepended to the rbg review payload."""
 
     def test_window_is_enforcer_threshold_plus_two(self, monkeypatch):
-        """_audit_window_turns() == ENFORCER_TOOL_CALL_THRESHOLD + 2."""
+        """_audit_window_turns() == RBG_TOOL_CALL_THRESHOLD + 2."""
         import importlib
 
         from lib.gates import custom_actions
 
-        monkeypatch.setenv("ENFORCER_TOOL_CALL_THRESHOLD", "30")
+        monkeypatch.setenv("RBG_TOOL_CALL_THRESHOLD", "30")
         importlib.reload(sys.modules["hooks.gate_config"])
         assert custom_actions._audit_window_turns() == 32
 

--- a/tests/hooks/test_gate_config.py
+++ b/tests/hooks/test_gate_config.py
@@ -225,7 +225,7 @@ class TestGeminiToolCoverage:
         assert (
             get_tool_category("some_future_spawn_tool", {"agent_name": "rbg"}) == "infrastructure"
         )
-        assert get_tool_category("some_future_spawn_tool", {"name": "enforcer"}) == "infrastructure"
+        assert get_tool_category("some_future_spawn_tool", {"name": "rbg"}) == "infrastructure"
 
     def test_structural_escape_hatch_does_not_trigger_for_non_compliance_agents(self):
         """(c-neg) tool_input with a non-compliance agent name does NOT escape to infrastructure."""

--- a/tests/hooks/test_gate_context_injection.py
+++ b/tests/hooks/test_gate_context_injection.py
@@ -214,7 +214,7 @@ class TestPreToolUseBlockHasContextInjection:
     def test_enforcer_block_has_context(self, router):
         """Enforcer gate blocking at threshold must include context_injection."""
         state = SessionState.create("test-ptu-ctx", client_type="claude")
-        state.gates["enforcer"].ops_since_open = 75
+        state.gates["rbg"].ops_since_open = 75
 
         ctx = HookContext(
             session_id="test-ptu-ctx",

--- a/tests/hooks/test_gate_hygiene_engine.py
+++ b/tests/hooks/test_gate_hygiene_engine.py
@@ -43,8 +43,8 @@ def _state_with_enforcer_overdue():
     """Session state with the enforcer gate past its block threshold."""
     state = SessionState.create("ws7-engine-test", client_type="claude")
     state.main_agent.current_task = "task-x"  # so the gate is "armed"
-    state.gates["enforcer"].status = GateStatus.OPEN
-    state.gates["enforcer"].ops_since_open = 999
+    state.gates["rbg"].status = GateStatus.OPEN
+    state.gates["rbg"].ops_since_open = 999
     return state
 
 
@@ -62,7 +62,7 @@ def _verdict(result):
 def test_enforcer_blocks_write_at_threshold(monkeypatch):
     """Control: an overdue enforcer DOES deny an ordinary write tool."""
     monkeypatch.setenv("ENFORCER_GATE_MODE", "block")
-    gate = GenericGate(_CONFIGS["enforcer"])
+    gate = GenericGate(_CONFIGS["rbg"])
     result = gate.check(_ctx("Write"), _state_with_enforcer_overdue())
     assert _verdict(result) == "deny"
 
@@ -74,7 +74,7 @@ def test_enforcer_does_not_block_askuserquestion(monkeypatch):
     must NOT fire, because AskUserQuestion is on the never-block list.
     """
     monkeypatch.setenv("ENFORCER_GATE_MODE", "block")
-    gate = GenericGate(_CONFIGS["enforcer"])
+    gate = GenericGate(_CONFIGS["rbg"])
     result = gate.check(_ctx("AskUserQuestion"), _state_with_enforcer_overdue())
     assert _verdict(result) != "deny", (
         "AskUserQuestion must never be denied by a gate (never-block, #1451)"

--- a/tests/hooks/test_gate_replay.py
+++ b/tests/hooks/test_gate_replay.py
@@ -77,10 +77,10 @@ def _reinit_gates_with_defaults():
 def _set_gate_modes(monkeypatch, **modes) -> None:
     monkeypatch.setenv("HANDOVER_GATE_MODE", modes.get("handover", "warn"))
     monkeypatch.setenv("QA_GATE_MODE", modes.get("qa", "block"))
-    monkeypatch.setenv("ENFORCER_GATE_MODE", modes.get("enforcer", "block"))
+    monkeypatch.setenv("RBG_GATE_MODE", modes.get("enforcer", "block"))
     monkeypatch.setenv("HYDRATION_GATE_MODE", modes.get("hydration", "off"))
     monkeypatch.setenv("IDA_GATE_MODE", modes.get("ida", "off"))
-    monkeypatch.setenv("ENFORCER_TOOL_CALL_THRESHOLD", str(modes.get("enforcer_threshold", 50)))
+    monkeypatch.setenv("RBG_TOOL_CALL_THRESHOLD", str(modes.get("enforcer_threshold", 50)))
 
 
 @pytest.fixture(autouse=True)
@@ -156,7 +156,7 @@ class TestRealEventInvariants:
         """Real compliance agent spawns must always be allowed."""
         state = SessionState.create("test-replay")
         # Hostile state: enforcer at threshold
-        state.gates["enforcer"].ops_since_open = 100
+        state.gates["rbg"].ops_since_open = 100
         ctx = _make_context(event)
 
         result = router._dispatch_gates(ctx, state)
@@ -176,7 +176,7 @@ class TestRealEventInvariants:
     def test_always_available_tools_from_real_logs(self, router, event):
         """Real always-available tool calls must pass even with hostile state."""
         state = SessionState.create("test-replay")
-        state.gates["enforcer"].ops_since_open = 100
+        state.gates["rbg"].ops_since_open = 100
         ctx = _make_context(event)
 
         result = router._dispatch_gates(ctx, state)
@@ -336,7 +336,7 @@ class TestHookLogDiscovery:
             pytest.skip("No compliance agent PreToolUse events found in logs")
 
         state = SessionState.create("test-compliance-disk")
-        state.gates["enforcer"].ops_since_open = 100
+        state.gates["rbg"].ops_since_open = 100
 
         for event in compliance_events:
             ctx = HookContext(
@@ -367,10 +367,10 @@ class TestPostToolUseCounter:
     def test_ops_counter_increments_on_write_tool(self, router):
         """PostToolUse for write tools must increment ops_since_open."""
         state = SessionState.create("test-counter")
-        state.gates["enforcer"].status = GateStatus.OPEN
-        state.gates["enforcer"].ops_since_open = 0
+        state.gates["rbg"].status = GateStatus.OPEN
+        state.gates["rbg"].ops_since_open = 0
 
-        initial_ops = state.gates["enforcer"].ops_since_open
+        initial_ops = state.gates["rbg"].ops_since_open
 
         # Simulate PostToolUse for a write tool
         ctx = HookContext(
@@ -381,16 +381,16 @@ class TestPostToolUseCounter:
         )
         router._dispatch_gates(ctx, state)
 
-        assert state.gates["enforcer"].ops_since_open == initial_ops + 1, (
+        assert state.gates["rbg"].ops_since_open == initial_ops + 1, (
             f"ops_since_open should increment from {initial_ops} to {initial_ops + 1}, "
-            f"got {state.gates['enforcer'].ops_since_open}"
+            f"got {state.gates['rbg'].ops_since_open}"
         )
 
     def test_ops_counter_increments_multiple_times(self, router):
         """Multiple PostToolUse events should increment the counter each time."""
         state = SessionState.create("test-counter-multi")
-        state.gates["enforcer"].status = GateStatus.OPEN
-        state.gates["enforcer"].ops_since_open = 0
+        state.gates["rbg"].status = GateStatus.OPEN
+        state.gates["rbg"].ops_since_open = 0
 
         for i in range(5):
             ctx = HookContext(
@@ -401,16 +401,16 @@ class TestPostToolUseCounter:
             )
             router._dispatch_gates(ctx, state)
 
-        assert state.gates["enforcer"].ops_since_open == 5, (
+        assert state.gates["rbg"].ops_since_open == 5, (
             f"ops_since_open should be 5 after 5 PostToolUse events, "
-            f"got {state.gates['enforcer'].ops_since_open}"
+            f"got {state.gates['rbg'].ops_since_open}"
         )
 
     def test_enforcer_counter_resets_after_compliance_check(self, router):
         """Counter should reset to 0 when enforcer SubagentStop fires."""
         state = SessionState.create("test-counter-reset")
-        state.gates["enforcer"].status = GateStatus.OPEN
-        state.gates["enforcer"].ops_since_open = 42
+        state.gates["rbg"].status = GateStatus.OPEN
+        state.gates["rbg"].ops_since_open = 42
 
         # Simulate enforcer SubagentStop
         ctx = HookContext(
@@ -418,13 +418,13 @@ class TestPostToolUseCounter:
             hook_event="SubagentStop",
             tool_name=None,
             tool_input={},
-            subagent_type="aops-core:enforcer",
+            subagent_type="aops-core:rbg",
         )
         router._dispatch_gates(ctx, state)
 
-        assert state.gates["enforcer"].ops_since_open == 0, (
+        assert state.gates["rbg"].ops_since_open == 0, (
             f"ops_since_open should reset to 0 after enforcer check, "
-            f"got {state.gates['enforcer'].ops_since_open}"
+            f"got {state.gates['rbg'].ops_since_open}"
         )
 
 
@@ -439,8 +439,8 @@ class TestCountdownWarning:
     def test_countdown_warning_in_range(self, router):
         """Ops at 45 (within 43-49 range) should produce countdown message."""
         state = SessionState.create("test-countdown", client_type="claude")
-        state.gates["enforcer"].status = GateStatus.OPEN
-        state.gates["enforcer"].ops_since_open = 45  # threshold=50, start_before=7
+        state.gates["rbg"].status = GateStatus.OPEN
+        state.gates["rbg"].ops_since_open = 45  # threshold=50, start_before=7
 
         ctx = HookContext(
             session_id="test-countdown",
@@ -461,8 +461,8 @@ class TestCountdownWarning:
     def test_no_countdown_below_range(self, router):
         """Ops at 10 (well below range) should not produce countdown."""
         state = SessionState.create("test-no-countdown")
-        state.gates["enforcer"].status = GateStatus.OPEN
-        state.gates["enforcer"].ops_since_open = 10
+        state.gates["rbg"].status = GateStatus.OPEN
+        state.gates["rbg"].ops_since_open = 10
 
         ctx = HookContext(
             session_id="test-no-countdown",
@@ -479,8 +479,8 @@ class TestCountdownWarning:
     def test_no_countdown_at_threshold(self, router):
         """Ops at 50 (at threshold) should produce policy block, not countdown."""
         state = SessionState.create("test-at-threshold", client_type="claude")
-        state.gates["enforcer"].status = GateStatus.OPEN
-        state.gates["enforcer"].ops_since_open = 50
+        state.gates["rbg"].status = GateStatus.OPEN
+        state.gates["rbg"].ops_since_open = 50
 
         ctx = HookContext(
             session_id="test-at-threshold",
@@ -561,8 +561,8 @@ class TestTempPathValidation:
     def test_enforcer_context_injection_contains_temp_path(self, router):
         """When enforcer gate fires, context injection must contain temp_path."""
         state = SessionState.create("test-enforcer-path")
-        state.gates["enforcer"].status = GateStatus.OPEN
-        state.gates["enforcer"].ops_since_open = 55
+        state.gates["rbg"].status = GateStatus.OPEN
+        state.gates["rbg"].ops_since_open = 55
 
         ctx = HookContext(
             session_id="test-enforcer-path",
@@ -582,7 +582,7 @@ class TestTempPathValidation:
 
         assert result is not None
         # temp_path should have been set by the custom action mock
-        temp_path = state.gates["enforcer"].metrics.get("temp_path")
+        temp_path = state.gates["rbg"].metrics.get("temp_path")
         assert temp_path is not None, "Enforcer policy should set temp_path in metrics"
         assert result.context_injection is not None, (
             "Enforcer gate should produce context injection"
@@ -819,7 +819,7 @@ REAL_TOOL_NAMES: list[tuple[str, str, str]] = [
     ("shell", "write", "Gemini: shell"),
     ("cli_help", "read_only", "Gemini: cli help"),
     # ===== Agent/subagent type names that appeared as tool_name (bug/edge case) =====
-    ("enforcer", "infrastructure", "subagent name as tool (enforcer)"),
+    ("rbg", "infrastructure", "subagent name as tool (rbg)"),
 ]
 
 # Build Agent/Skill spawn scenarios from real logs
@@ -937,7 +937,7 @@ class TestRealSpawnEventCategorization:
         """Spawn tools are in 'spawn' category."""
         state = SessionState.create("test-spawn-categorization")
         # Hostile state: enforcer at threshold
-        state.gates["enforcer"].ops_since_open = 100
+        state.gates["rbg"].ops_since_open = 100
 
         tool_input = (
             {"subagent_type": subagent_type, "prompt": "test"}

--- a/tests/hooks/test_gate_verdict_logic.py
+++ b/tests/hooks/test_gate_verdict_logic.py
@@ -20,8 +20,8 @@ from tests.hooks.gate_helpers import (
 # --- Gate mode override parameterisation ---
 
 _GATE_MODE_CASES = [
-    ("enforcer", "warn", GateVerdict.WARN),
-    ("enforcer", "block", GateVerdict.DENY),
+    ("rbg", "warn", GateVerdict.WARN),
+    ("rbg", "block", GateVerdict.DENY),
     ("qa", "warn", GateVerdict.WARN),
     ("qa", "block", GateVerdict.DENY),
     ("handover", "warn", GateVerdict.WARN),

--- a/tests/hooks/test_message_path_leak_coverage.py
+++ b/tests/hooks/test_message_path_leak_coverage.py
@@ -92,10 +92,10 @@ def _body_leaked_into(user_text: str | None, context_body: str) -> bool:
 # ---------------------------------------------------------------------------
 
 _TEMPLATE_VARS: dict[str, dict[str, object]] = {
-    "enforcer.policy_context": {"temp_path": "/tmp/enforcer-ctx.md", "ops_since_open": 50},
+    "rbg.policy_context": {"temp_path": "/tmp/rbg-ctx.md", "ops_since_open": 50},
     "qa.policy_context": {"temp_path": "/tmp/qa-gate.md"},
     "rbg_review.policy_context": {"temp_path": "/tmp/rbg-review.md"},
-    "enforcer.policy_message": {"ops_since_open": 50},
+    "rbg.policy_message": {"ops_since_open": 50},
 }
 
 
@@ -350,7 +350,7 @@ class TestEnforcerVerifiedSameKey:
     constitutes an instruction-text leak."""
 
     def test_enforcer_verified_template_is_short_status_not_instruction(self):
-        body = _render("enforcer.verified")
+        body = _render("rbg.verified")
         norm = _norm(body)
         # The template is a short status line, not a full instruction block.
         assert norm == "◇ Compliance verified.", (
@@ -360,7 +360,7 @@ class TestEnforcerVerifiedSameKey:
     def test_enforcer_verified_routes_same_body_to_both_channels(self, router):
         # Mirror the transition: both system_message and context_injection are
         # the SAME rendered body (no marker — transitions don't wrap).
-        body = _render("enforcer.verified")
+        body = _render("rbg.verified")
         canonical = CanonicalHookOutput(
             verdict="allow", system_message=body, context_injection=body
         )
@@ -451,11 +451,11 @@ class TestRealPipelineEnforcerLeak:
 
     @pytest.mark.parametrize("mode", ["warn", "block"])
     def test_real_enforcer_policy_context_absent_from_user(self, router, monkeypatch, mode):
-        set_gate_modes(monkeypatch, enforcer=mode)
+        set_gate_modes(monkeypatch, rbg=mode)
         reinit_gates_with_defaults()
 
-        state = make_gate_trigger_state("enforcer")
-        ctx = make_gate_trigger_context("enforcer")
+        state = make_gate_trigger_state("rbg")
+        ctx = make_gate_trigger_context("rbg")
 
         result = router._dispatch_gates(ctx, state)
         if result is None:

--- a/tests/hooks/test_subagent_gate_dispatch_regression.py
+++ b/tests/hooks/test_subagent_gate_dispatch_regression.py
@@ -234,8 +234,8 @@ class TestSubagentGateBypass:
         """
         session_id, state = mock_session
 
-        state.gates["enforcer"].ops_since_open = 100
-        state.gates["enforcer"].status = GateStatus.OPEN
+        state.get_gate("enforcer").ops_since_open = 100
+        state.get_gate("enforcer").status = GateStatus.OPEN
 
         ctx = HookContext(
             session_id=session_id,
@@ -256,8 +256,8 @@ class TestSubagentGateBypass:
         """Main session (is_subagent=False) must still be subject to gate policies."""
         session_id, state = mock_session
 
-        state.gates["enforcer"].ops_since_open = 100
-        state.gates["enforcer"].status = GateStatus.OPEN
+        state.get_gate("enforcer").ops_since_open = 100
+        state.get_gate("enforcer").status = GateStatus.OPEN
 
         ctx = HookContext(
             session_id=session_id,
@@ -400,8 +400,8 @@ class TestEvaluateTriggersMethod:
         session_id, state = mock_session
 
         # Set up high ops so policies WOULD fire
-        state.gates["enforcer"].ops_since_open = 100
-        state.gates["enforcer"].status = GateStatus.OPEN
+        state.get_gate("enforcer").ops_since_open = 100
+        state.get_gate("enforcer").status = GateStatus.OPEN
 
         ctx = HookContext(
             session_id=session_id,
@@ -422,8 +422,8 @@ class TestEvaluateTriggersMethod:
         """check() should evaluate BOTH triggers AND policies (contrast with evaluate_triggers)."""
         session_id, state = mock_session
 
-        state.gates["enforcer"].ops_since_open = 100
-        state.gates["enforcer"].status = GateStatus.OPEN
+        state.get_gate("enforcer").ops_since_open = 100
+        state.get_gate("enforcer").status = GateStatus.OPEN
 
         ctx = HookContext(
             session_id=session_id,
@@ -466,7 +466,7 @@ class TestReadOnlyToolExclusion:
         gate = GenericGate(config)
         session_id, state = mock_session
 
-        state.gates["enforcer_excl"] = state.gates["enforcer"].model_copy()
+        state.gates["enforcer_excl"] = state.get_gate("enforcer").model_copy()
         state.gates["enforcer_excl"].ops_since_open = 100
         state.gates["enforcer_excl"].status = GateStatus.OPEN
 
@@ -503,8 +503,8 @@ class TestSubagentStartHandler:
         session_id, state = mock_session
 
         # Enforcer trigger matches SubagentStart with subagent_type=enforcer
-        state.gates["enforcer"].ops_since_open = 50
-        state.gates["enforcer"].status = GateStatus.OPEN
+        state.get_gate("enforcer").ops_since_open = 50
+        state.get_gate("enforcer").status = GateStatus.OPEN
 
         ctx = HookContext(
             session_id=session_id,
@@ -524,7 +524,7 @@ class TestSubagentStartHandler:
             router.execute_hooks(ctx)
 
         # Trigger should have fired and reset ops counter
-        assert state.gates["enforcer"].ops_since_open == 0
+        assert state.get_gate("enforcer").ops_since_open == 0
 
     def test_on_subagent_start_method_exists(self):
         """GenericGate must have on_subagent_start method."""
@@ -536,8 +536,8 @@ class TestSubagentStartHandler:
         """on_subagent_start must evaluate triggers (same as on_subagent_stop)."""
         session_id, state = mock_session
 
-        state.gates["enforcer"].ops_since_open = 50
-        state.gates["enforcer"].status = GateStatus.OPEN
+        state.get_gate("enforcer").ops_since_open = 50
+        state.get_gate("enforcer").status = GateStatus.OPEN
 
         ctx = HookContext(
             session_id=session_id,
@@ -551,7 +551,7 @@ class TestSubagentStartHandler:
         result = gate.on_subagent_start(ctx, state)
 
         # Trigger should fire and reset ops
-        assert state.gates["enforcer"].ops_since_open == 0
+        assert state.get_gate("enforcer").ops_since_open == 0
         assert result is not None
 
 
@@ -567,8 +567,8 @@ class TestSubagentPostToolUseBypass:
         session_id, state = mock_session
 
         initial_ops = 10
-        state.gates["enforcer"].ops_since_open = initial_ops
-        state.gates["enforcer"].status = GateStatus.OPEN
+        state.get_gate("enforcer").ops_since_open = initial_ops
+        state.get_gate("enforcer").status = GateStatus.OPEN
 
         ctx = HookContext(
             session_id=session_id,
@@ -585,7 +585,7 @@ class TestSubagentPostToolUseBypass:
 
         # Subagent sessions return None — ops unchanged
         assert result is None
-        assert state.gates["enforcer"].ops_since_open == initial_ops
+        assert state.get_gate("enforcer").ops_since_open == initial_ops
 
     def test_non_compliance_subagent_post_tool_use_also_unchanged(
         self, mock_session, test_registry
@@ -594,8 +594,8 @@ class TestSubagentPostToolUseBypass:
         session_id, state = mock_session
 
         initial_ops = 10
-        state.gates["enforcer"].ops_since_open = initial_ops
-        state.gates["enforcer"].status = GateStatus.OPEN
+        state.get_gate("enforcer").ops_since_open = initial_ops
+        state.get_gate("enforcer").status = GateStatus.OPEN
 
         ctx = HookContext(
             session_id=session_id,
@@ -612,7 +612,7 @@ class TestSubagentPostToolUseBypass:
 
         # Subagent sessions return None — ops unchanged
         assert result is None
-        assert state.gates["enforcer"].ops_since_open == initial_ops
+        assert state.get_gate("enforcer").ops_since_open == initial_ops
 
 
 class TestSubagentStartStopIsNotSubagent:

--- a/tests/lib/test_enforcer_block.py
+++ b/tests/lib/test_enforcer_block.py
@@ -101,5 +101,5 @@ class TestEnforcerBlockIntegration:
         # Read and verify the state directly
         state = json.loads(session_files[0].read_text())
         # <!-- NS: these tests need to be refactored for the new pydantic objects. -->
-        assert state["gates"]["enforcer"]["blocked"] is True
-        assert state["gates"]["enforcer"]["block_reason"] == "Policy violation reason"
+        assert state["gates"]["rbg"]["blocked"] is True
+        assert state["gates"]["rbg"]["block_reason"] == "Policy violation reason"

--- a/tests/lib/test_gate_secret_scrubbing.py
+++ b/tests/lib/test_gate_secret_scrubbing.py
@@ -48,7 +48,7 @@ def test_create_audit_file_scrubs_secrets(tmp_path, monkeypatch):
     monkeypatch.setenv("AOPS_SESSION_STATE_DIR", str(tmp_path))
 
     # Invoke custom action helper that builds the enforcer gate file
-    gate_path = create_audit_file("test-session-secrets", "enforcer", ctx)
+    gate_path = create_audit_file("test-session-secrets", "rbg", ctx)
 
     assert gate_path.exists()
 

--- a/tests/lib/test_template_registry.py
+++ b/tests/lib/test_template_registry.py
@@ -72,8 +72,8 @@ def configured_registry(templates_dir: Path):
 
 def test_get_spec_returns_correct_spec(registry):
     """Verify spec lookup works for known templates."""
-    spec = registry.get_spec("enforcer.context")
-    assert spec.name == "enforcer.context"
+    spec = registry.get_spec("rbg.context")
+    assert spec.name == "rbg.context"
     assert spec.required_vars is not None
 
 
@@ -200,7 +200,7 @@ def test_list_templates_all(registry):
     """Lists all registered template names."""
     names = registry.list_templates()
     assert len(names) >= 10  # At least 10 templates defined
-    assert "enforcer.context" in names
+    assert "rbg.context" in names
 
 
 def test_list_templates_by_category(registry):
@@ -211,10 +211,10 @@ def test_list_templates_by_category(registry):
     assert len(user_messages) >= 1
 
     subagent = registry.list_templates(category=TemplateCategory.SUBAGENT_INSTRUCTION)
-    assert "enforcer.context" in subagent
+    assert "rbg.context" in subagent
 
     # User messages should not include subagent instructions
-    assert "enforcer.context" not in user_messages
+    assert "rbg.context" not in user_messages
 
 
 # =============================================================================
@@ -386,11 +386,11 @@ def test_spec_category_assignment(registry):
     from lib.template_registry import TemplateCategory
 
     # Context injection
-    assert registry.get_spec("enforcer.instruction").category == TemplateCategory.CONTEXT_INJECTION
+    assert registry.get_spec("rbg.instruction").category == TemplateCategory.CONTEXT_INJECTION
     assert registry.get_spec("stop.handover_block").category == TemplateCategory.CONTEXT_INJECTION
 
     # Subagent instruction
-    assert registry.get_spec("enforcer.context").category == TemplateCategory.SUBAGENT_INSTRUCTION
+    assert registry.get_spec("rbg.context").category == TemplateCategory.SUBAGENT_INSTRUCTION
 
 
 # =============================================================================

--- a/tests/test_cowork_markers.py
+++ b/tests/test_cowork_markers.py
@@ -74,25 +74,9 @@ def test_trailing_whitespace_on_markers_handled() -> None:
 # The cowork build drops the bundled hook stack: aops-core, installed into Cowork
 # from the nicsuzor/aops main `dist` marketplace, supplies the one shared hook
 # stack for both surfaces. Bundling hooks here too would register the router a
-# second time and double-fire every lifecycle hook. With no `hooks/` package on
-# disk, the cowork pyproject must NOT list `hooks` under hatch's wheel packages or
-# `uv sync --frozen` would fail at runtime.
-
-
-def test_cowork_pyproject_excludes_hooks_package() -> None:
-    """Cowork's pyproject lists only `lib` — no `hooks` package."""
-    pyproject = _build.generate_aops_core_pyproject("9.9.9", "cowork")
-    assert 'packages = ["lib"]' in pyproject
-    assert '"hooks"' not in pyproject, "cowork pyproject must not declare the dropped hooks package"
-
-
-def test_cowork_pyproject_sourced_from_real_package() -> None:
-    """The cowork pyproject is the tracked aops-cowork package manifest (name
-    aops-cowork), with the build version stamped in — NOT a trimmed copy of
-    aops-core's manifest fabricated at build time."""
-    pyproject = _build.generate_aops_core_pyproject("9.9.9", "cowork")
-    assert 'name = "aops-cowork"' in pyproject
-    assert 'version = "9.9.9"' in pyproject
+# second time and double-fire every lifecycle hook. Cowork has no Python deps of
+# its own either, so build_aops_core ships no pyproject.toml/uv.lock at all for
+# it — there's nothing to declare, rather than a manifest to trim.
 
 
 def test_claude_pyproject_retains_hooks_package() -> None:
@@ -126,14 +110,11 @@ def test_cowork_package_manifest_is_tracked_source() -> None:
     assert manifest["name"] == "aops-cowork"
 
 
-def test_cowork_package_pyproject_is_tracked_and_lib_only() -> None:
-    """aops-cowork/pyproject.toml exists in source and ships lib only (no hooks)."""
-    pyproject_path = _COWORK_PKG / "pyproject.toml"
-    assert pyproject_path.is_file(), f"{pyproject_path} must be tracked source"
-    text = pyproject_path.read_text()
-    assert 'name = "aops-cowork"' in text
-    assert 'packages = ["lib"]' in text
-    assert '"hooks"' not in text
+def test_cowork_package_has_no_pyproject() -> None:
+    """aops-cowork ships no pyproject.toml — it has no Python deps of its own
+    (see build_aops_core's cowork skip); don't resurrect a tracked or generated
+    one here."""
+    assert not (_COWORK_PKG / "pyproject.toml").exists()
 
 
 def test_cowork_sync_skill_lives_in_package() -> None:

--- a/tests/test_session_naming.py
+++ b/tests/test_session_naming.py
@@ -419,11 +419,9 @@ class TestParseSessionFilename:
         assert parsed.slug == "fix-lint"
 
     def test_gate_variant(self):
-        parsed = parse_session_filename(
-            "20260411-1430-a1b2c3d4-academicops-claude-session-enforcer.md"
-        )
+        parsed = parse_session_filename("20260411-1430-a1b2c3d4-academicops-claude-session-rbg.md")
         assert parsed is not None
-        assert parsed.variant == "-enforcer"
+        assert parsed.variant == "-rbg"
         assert parsed.slug == "session"
 
     def test_with_directory_prefix(self):

--- a/tests/test_subagent_gates.py
+++ b/tests/test_subagent_gates.py
@@ -236,7 +236,7 @@ def test_regex_hook_event_matching():
         hook_event="^(SubagentStop|PostToolUse)$", subagent_type_pattern="enforcer"
     )
 
-    enforcer_config = next(g for g in GATE_CONFIGS if g.name == "enforcer")
+    enforcer_config = next(g for g in GATE_CONFIGS if g.name == "rbg")
     gate = GenericGate(enforcer_config)
 
     # Matches


### PR DESCRIPTION
## Summary
- `dev` has been red on Pytest (a required check) since commits `12ada1b2` and `a29e807e` landed directly on the branch with no PR — they renamed the enforcer gate to rbg but left ~140 test references on the old names, so every open PR was permanently blocked regardless of approval (base-broken-Pytest guard in `pr-pipeline.md` §3.8 correctly refuses to touch it).
- Fixes one real production bug in `aops-core/hooks/router.py` (`spec.agent_without_block` → `spec.agent_context_without_block`), completes the enforcer→rbg rename across ~20 test files (gate keys, env vars, template names, subagent_type values — each checked against the real source of truth, not blind find-replace), and cleans up `aops-cowork`'s packaging per Nic's direction (no pyproject.toml/uv.lock for cowork at all).

## Test plan
- [x] Full suite green locally: 2725 passed, 51 skipped, 0 failed
- [ ] CI Pytest/Lint/Type Check green on this PR
- [ ] Confirm PRs #2031 and #2030 (already approved, previously blocked only by base Pytest) auto-merge once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AN5zLQebBgXuFN1DhizNR