### PR TITLE
feat(pipeline): release-please fast path — merge on green lint+pytest, one approval at deploy

### DIFF
--- a/.github/workflows/agent-enforcer.yml
+++ b/.github/workflows/agent-enforcer.yml
@@ -47,7 +47,10 @@ jobs:
     name: Enforcer Review
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && inputs.ref && startsWith(inputs.ref, 'release-please')) && 'production' || '' }}
+    # (No environment gate.) The release-please `production` gate that used to sit
+    # here is retired — release-please PRs no longer run the enforcer at all
+    # (pr-pipeline.yml skips it; `release-autogreen` posts enforcer-status green).
+    # The single release approval now lives on the deploy step (build-extension.yml).
     outputs:
       committed: ${{ steps.check-commit.outputs.committed || 'false' }}
     concurrency:

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -34,6 +34,14 @@ jobs:
   build-and-deploy:
     name: Build extensions and publish release assets
     runs-on: ubuntu-latest
+    # SINGLE human approval for the whole release (pr-pipeline.md §3.13). The release
+    # PR now auto-merges on green Lint+Pytest with no PR-level gate, so the one
+    # human decision moved here — to the actual publish. A STABLE `vX.Y.Z` deploy
+    # (created automatically by release-please) waits on the `production` environment
+    # reviewer before it ships to the `dist` branch / Docker `:latest`. Prerelease
+    # tags (`vX.Y.Z-rc.N`, `-dev.N`, …; they contain a '-') are hand-pushed via
+    # `make prerelease` — that deliberate push IS the approval, so they skip the gate.
+    environment: ${{ !contains(github.ref_name, '-') && 'production' || '' }}
     permissions:
       contents: write
       packages: write   # push ghcr.io/nicsuzor/aops-crew on stable tags (A3)

--- a/.github/workflows/pr-pipeline.yml
+++ b/.github/workflows/pr-pipeline.yml
@@ -47,14 +47,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ─── Step 0: Gate (Approval for release-please PRs) ──────────────
+  # ─── Step 0: Gate (passthrough) ──────────────────────────────────
+  # No-op passthrough kept so downstream jobs' `needs: [gate]` edges are stable.
+  # The `production` Environment approval that USED to sit here for release-please
+  # PRs is retired: it blocked even Lint/Pytest behind a buried "Review
+  # deployments → Approve" click, and it duplicated the human gate. The single
+  # release approval now lives on the actual publish step (build-extension.yml's
+  # `production` environment, stable tags only) — so a release-please PR flows on
+  # green mechanical checks and the human approves ONCE, at deploy time. Regular
+  # PRs are unaffected (they were never gated here — the environment expression
+  # only ever resolved to 'production' for release-please head refs).
   gate:
-    name: Release Gate Approval
+    name: Gate (passthrough)
     runs-on: ubuntu-latest
-    environment: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref && startsWith(github.event.pull_request.head.ref, 'release-please')) && 'production' || '' }}
     steps:
-      - name: Acknowledge approval
-        run: echo "Environment gate approved or bypassed"
+      - name: Acknowledge
+        run: echo "Gate passthrough — release approval relocated to build-extension.yml (deploy step)."
 
   # ─── Step 0.4: Guard — no built artifacts on dev ───────────────────
   # dev is source-only. Built plugin dirs, dist/, and the GENERATED manifest
@@ -210,7 +218,9 @@ jobs:
   # parallel so a slow alignment surface never delays the merge-gate agents.
   alignment-queue:
     needs: [gate]
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Release-please PRs are not queued for alignment review (§3.13) — advisory
+    # signal only, and there is nothing strategic to align on a version bump.
+    if: github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.event.pull_request.head.ref, 'release-please')
     name: Alignment Queue
     runs-on: ubuntu-latest
     env:
@@ -269,10 +279,16 @@ jobs:
   # the bare `needs: [lint]` edge used to provide.
   enforcer:
     needs: [lint, initialize]
+    # Release-please PRs skip the agent reviewers entirely (§3.13): they are
+    # deterministic bot-generated version bumps + changelog + uv.lock — nothing
+    # for rbg/marsha to review. `release-autogreen` posts their required statuses
+    # green from the mechanical checks instead. For workflow_call / non-PR events
+    # `head.ref` is empty, so the guard is a no-op there.
     if: >-
       always() &&
       needs.lint.result == 'success' &&
       needs.lint.outputs.committed != 'true' &&
+      !startsWith(github.event.pull_request.head.ref, 'release-please') &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       (github.event_name != 'pull_request' || github.event.action != 'synchronize' || needs.initialize.outputs.admitted == 'true')
     name: Enforcer Review
@@ -296,7 +312,10 @@ jobs:
   # or `cancelled`, neither of which is a verdict on this SHA.
   qa:
     needs: [enforcer, lint]
-    if: always() && needs.lint.result == 'success' && (needs.enforcer.result == 'success' || needs.enforcer.result == 'failure') && needs.lint.outputs.committed != 'true' && needs.enforcer.outputs.committed != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    # Release-please PRs skip QA too (§3.13) — see the enforcer guard. In practice
+    # enforcer is already skipped for release PRs (so qa would skip via the
+    # result-gate below anyway), but the explicit guard keeps the intent local.
+    if: always() && needs.lint.result == 'success' && (needs.enforcer.result == 'success' || needs.enforcer.result == 'failure') && needs.lint.outputs.committed != 'true' && needs.enforcer.outputs.committed != 'true' && !startsWith(github.event.pull_request.head.ref, 'release-please') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     name: QA Verification
     uses: ./.github/workflows/agent-qa.yml
     with:
@@ -497,7 +516,11 @@ jobs:
   review-attestation:
     name: Review Attestation
     needs: [enforcer, qa]
-    if: always() && github.event.pull_request.head.repo.full_name == github.repository && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    # Release-please PRs skip this job (§3.13): the reviewers it attests are
+    # deliberately not run, so the attestation script would fail-close on their
+    # absence. `release-autogreen` posts the required `review-attestation=success`
+    # for release PRs instead (with the §10 target_sha in its target_url).
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.event.pull_request.head.ref, 'release-please') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -531,6 +554,70 @@ jobs:
             exit 1
           fi
           echo "::notice::$DESC"
+
+  # ─── Release-please fast path (§3.13) ────────────────────────────
+  # Release-please PRs (head ref `release-please--*`) are bot-generated,
+  # deterministic version bumps + CHANGELOG + uv.lock. There is nothing for the
+  # agent reviewers to judge, so they are skipped (guards on enforcer / qa /
+  # review-attestation / alignment-queue above). This job instead AUTO-SATISFIES
+  # the four agent/human required checks — `enforcer-status`, `qa-status`,
+  # `review-attestation`, `admit-status` — once the MECHANICAL gates (`Lint` and
+  # `Pytest`) are genuinely green on HEAD, then arms auto-merge. The result: a
+  # release PR merges on green lint+pytest with NO PR-level human step. The single
+  # human approval for the whole release lives at the deploy (build-extension.yml's
+  # `production` environment, stable tags only) — approve once, at publish time.
+  #
+  # Requires the bot PAT: the default GITHUB_TOKEN cannot post a status the ruleset
+  # trusts as a required check (§4.7). Same-repo PRs only (a fork run cannot mint
+  # the token) — mirrors the `initialize` gating.
+  release-autogreen:
+    name: Release PR auto-green
+    needs: [lint, pytest]
+    if: >-
+      always() &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release-please') &&
+      needs.lint.result == 'success' &&
+      needs.pytest.result == 'success' &&
+      needs.lint.outputs.committed != 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
+    env:
+      GH_TOKEN: ${{ secrets.AOPS_BOT_GH_TOKEN }}
+      REPO: ${{ github.repository }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Post agent + admit required statuses green
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::AOPS_BOT_GH_TOKEN is not set; cannot satisfy required checks for the release PR." >&2
+            exit 1
+          fi
+          for ctx in enforcer-status qa-status admit-status; do
+            gh api "repos/$REPO/statuses/$HEAD_SHA" \
+              -f state="success" \
+              -f context="$ctx" \
+              -f description="Auto-satisfied for release-please PR (deterministic bump — agent review + human PR gate bypassed; §3.13)" \
+              -f target_url="$RUN_URL"
+          done
+          # review-attestation carries the §10 target_sha in its target_url so a
+          # human/audit can confirm it was posted for THIS head SHA.
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state="success" \
+            -f context="review-attestation" \
+            -f description="Auto-attested for release-please PR (reviewers deliberately skipped; §3.13)" \
+            -f target_url="$RUN_URL?target_sha=$HEAD_SHA"
+      - name: Arm auto-merge
+        run: |
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash --delete-branch \
+            || echo "WARNING: could not enable auto-merge (may already be enabled, or PR already merged)"
 
   # ─── Read-only checks (typecheck, pytest) ────────────────────────
   # These contribute statuses but never end a pass. They only run if

--- a/specs/workflows/pr-pipeline.md
+++ b/specs/workflows/pr-pipeline.md
@@ -789,6 +789,58 @@ fire the normal `pull_request` pipeline, so Stage-2 re-verification (§3.5), pas
 > does not re-dispatch every tick; a human push or re-resolution (new SHA) re-enters the sweep.
 > The §3.6 exhaustion handler bounds repeated mechanic passes within a single admission.
 
+### 3.13 Release-please fast path — mechanical checks only, one approval at deploy — **LIVE**
+
+Release-please PRs (head ref `release-please--*`) are **not** subject to the agent
+pipeline. They are bot-generated, deterministic artifacts — a version bump, a
+regenerated `CHANGELOG`, and `uv.lock` — produced by `release-please.yml` from the
+merged conventional-commit history. There is nothing for rbg (enforcer) or marsha
+(qa) to judge: the content is mechanically derived, not authored. Subjecting them to
+the full triage/admission machinery was pure friction (the symptom that motivated
+this path: release PRs stalling behind an unrelated buried approval and repeated
+agent runs).
+
+**What runs.** Only the mechanical gates — `Lint` and `Pytest` (and the informational,
+non-required `Type Check`). These are the real signal on a release PR: does the tree
+still lint and do the tests still pass at the bumped version.
+
+**What is skipped.** `enforcer`, `qa`, `review-attestation`, `alignment-queue`, the
+pre-admission responder, and the Stage-2 mechanic all carry a
+`!startsWith(github.event.pull_request.head.ref, 'release-please')` guard (or cascade
+off the skipped reviewers). No agent runner is burned on a release PR.
+
+**How the required checks are satisfied.** The branch-protection ruleset (§7) requires
+`enforcer-status`, `qa-status`, `review-attestation`, and `admit-status` for **every**
+PR to `dev`, and a GitHub ruleset cannot conditionally drop required checks by head
+ref. So the `release-autogreen` job (in `pr-pipeline.yml`) posts all four as `success`
+the moment `Lint` **and** `Pytest` are genuinely green on HEAD, then arms auto-merge
+(`--squash --delete-branch`). `review-attestation` is posted with the §10 `target_sha`
+in its `target_url` so the auto-attestation is auditable against the head SHA. The job
+requires `AOPS_BOT_GH_TOKEN` (the default token cannot satisfy a ruleset-trusted
+required check, §4.7) and is same-repo only, mirroring `initialize`.
+
+**The single human approval lives at deploy, not on the PR.** The maintainer asked for
+exactly one approval, at the deployment. So the release PR itself has **no** human gate
+— it merges automatically on green mechanical checks — and the one approval is the
+`production` GitHub Environment on `build-extension.yml`'s `build-and-deploy` job. A
+**stable** `vX.Y.Z` deploy (the tag release-please creates automatically on the next
+`push: dev`) waits on the environment reviewer before publishing to the `dist` branch
+and Docker `:latest`. **Prerelease** tags (`vX.Y.Z-rc.N`, `-dev.N`, …; they contain a
+`-`) are hand-pushed via `make prerelease`, so that deliberate push *is* the approval
+and they skip the gate (`environment: ${{ !contains(github.ref_name, '-') && 'production' || '' }}`).
+
+> **Trade-off, recorded deliberately.** This is a scoped exception to the repository's
+> "never merge without Nic" invariant (§5, `bypass_actors: null`): a release PR merges
+> to `dev` with no per-PR human click. It is safe because (a) the content is
+> deterministic bot output, not authored change, and (b) the human decision is not
+> removed but **relocated** to the publish step — nothing ships to users until the
+> `production` environment is approved. The retired `production` gate on the *PR
+> pipeline* `gate` job (and the dead copy on `agent-enforcer.yml`) blocked even
+> Lint/Pytest behind a buried "Review deployments → Approve" and duplicated the human
+> gate; it is gone. This exception applies ONLY to `release-please--*` head refs; every
+> other PR to `dev` still runs the full agent pipeline and the `admit-status` human
+> gate unchanged.
+
 ## 4. Per-agent contract (locked)
 
 Every agent in the pipeline — enforcer, qa, mechanic, alignment, and any future agent —

--- a/tests/test_release_please_fast_path.py
+++ b/tests/test_release_please_fast_path.py
@@ -1,0 +1,103 @@
+"""Static wiring tests for the release-please fast path (pr-pipeline.md §3.13).
+
+Release-please PRs (head ref `release-please--*`) are deterministic bot output —
+version bump + CHANGELOG + uv.lock. They skip the agent reviewers and merge on
+green Lint+Pytest; the single human approval is relocated to the deploy step
+(`build-extension.yml`'s `production` environment). These assert the structure
+the runtime behaviour depends on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PIPELINE = REPO_ROOT / ".github" / "workflows" / "pr-pipeline.yml"
+BUILD = REPO_ROOT / ".github" / "workflows" / "build-extension.yml"
+ENFORCER = REPO_ROOT / ".github" / "workflows" / "agent-enforcer.yml"
+
+RELEASE_GUARD = "!startsWith(github.event.pull_request.head.ref, 'release-please')"
+
+
+def _jobs(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())["jobs"]
+
+
+# ── The agent reviewers skip release-please PRs ──────────────────────────────
+
+
+def test_agent_reviewers_skip_release_please_prs():
+    """enforcer / qa / review-attestation / alignment-queue must each carry the
+    release-please skip guard, so no agent runner fires on a release PR."""
+    jobs = _jobs(PIPELINE)
+    for name in ("enforcer", "qa", "review-attestation", "alignment-queue"):
+        assert RELEASE_GUARD in jobs[name]["if"], (name, jobs[name]["if"])
+
+
+# ── release-autogreen satisfies the required checks from mechanical green ────
+
+
+def test_release_autogreen_job_exists_and_is_gated():
+    """The fast-path job runs ONLY for same-repo release-please PRs and ONLY once
+    Lint AND Pytest are green with no lint autofix commit."""
+    jobs = _jobs(PIPELINE)
+    assert "release-autogreen" in jobs, "release-autogreen job missing from pr-pipeline.yml"
+    job = jobs["release-autogreen"]
+    assert set(job["needs"]) == {"lint", "pytest"}, job["needs"]
+    cond = job["if"]
+    assert "startsWith(github.event.pull_request.head.ref, 'release-please')" in cond, cond
+    assert "needs.lint.result == 'success'" in cond, cond
+    assert "needs.pytest.result == 'success'" in cond, cond
+    assert "needs.lint.outputs.committed != 'true'" in cond, cond
+    assert "head.repo.full_name == github.repository" in cond, cond
+
+
+def test_release_autogreen_posts_all_required_agent_statuses():
+    """It must post enforcer-status, qa-status, admit-status, AND review-attestation
+    green — the four ruleset-required checks the reviewers would otherwise own — and
+    arm auto-merge. review-attestation must carry the §10 target_sha."""
+    job = _jobs(PIPELINE)["release-autogreen"]
+    body = "\n".join(s.get("run", "") for s in job["steps"] if isinstance(s, dict))
+    for ctx in ("enforcer-status", "qa-status", "admit-status", "review-attestation"):
+        assert ctx in body, f"{ctx} not posted by release-autogreen:\n{body}"
+    assert 'state="success"' in body, body
+    assert "target_sha=$HEAD_SHA" in body, body  # attestation auditable to the head SHA
+    assert "--auto" in body and "gh pr merge" in body, body
+
+
+def test_release_autogreen_uses_bot_pat():
+    """A ruleset-trusted required check cannot be posted with the default token
+    (§4.7) — the job must use AOPS_BOT_GH_TOKEN."""
+    job = _jobs(PIPELINE)["release-autogreen"]
+    assert "AOPS_BOT_GH_TOKEN" in str(job.get("env", {})), job.get("env")
+
+
+# ── The PR-pipeline gate no longer imposes an Environment approval ───────────
+
+
+def test_gate_job_has_no_environment_approval():
+    """The retired `production` gate on the PR pipeline blocked even Lint/Pytest;
+    the gate job must now be a plain passthrough with no `environment:`."""
+    gate = _jobs(PIPELINE)["gate"]
+    assert "environment" not in gate, gate.get("environment")
+
+
+def test_enforcer_reusable_workflow_has_no_release_environment():
+    """The dead release-please `production` environment on agent-enforcer.yml is
+    removed (release PRs no longer run the enforcer at all)."""
+    enf = _jobs(ENFORCER)["enforcer"]
+    assert "environment" not in enf, enf.get("environment")
+
+
+# ── The single approval lives at the deploy step ─────────────────────────────
+
+
+def test_deploy_step_gates_stable_releases_on_production_environment():
+    """build-extension's build-and-deploy job carries the single human approval:
+    a `production` environment on stable tags (no '-'); prerelease tags skip it."""
+    job = _jobs(BUILD)["build-and-deploy"]
+    env = job.get("environment", "")
+    assert "production" in env, env
+    assert "contains(github.ref_name, '-')" in env, env  # prereleases skip the gate


### PR DESCRIPTION
## Problem

Release-please PRs (like #2003) stalled: they were forced through the **full agent pipeline** (enforcer/qa/review-attestation/mechanic/alignment) *and* a buried `production` GitHub Environment approval on the pipeline `gate` job — which blocked even Lint/Pytest until someone clicked "Review deployments → Approve" inside an Actions run. A release PR is deterministic bot output (version bump + `CHANGELOG` + `uv.lock`); there is nothing for rbg/marsha to review.

Requested behaviour: a release PR should just need green **pytest, lint, typecheck**, with a single human approval — at the deployment.

## Changes

- **Skip the agent reviewers for `release-please--*` head refs.** Guards on `enforcer`, `qa`, `review-attestation`, and `alignment-queue`; the responder/mechanic cascade off the skipped reviewers. No agent runner fires on a release PR.
- **New `release-autogreen` job.** A GitHub ruleset can't conditionally drop required checks by head ref, so this job auto-satisfies the four required agent/human statuses (`enforcer-status`, `qa-status`, `review-attestation`, `admit-status`) as `success` once **Lint AND Pytest are genuinely green on HEAD**, then arms auto-merge. `review-attestation` carries the §10 `target_sha` so the auto-attestation is auditable. Uses `AOPS_BOT_GH_TOKEN` (default token can't satisfy a ruleset-trusted check).
- **Relocate the single human approval to the actual deploy.** `build-extension.yml`'s `build-and-deploy` job now carries the `production` environment on **stable `vX.Y.Z` tags only** (`environment: ${{ !contains(github.ref_name, '-') && 'production' || '' }}`). Prerelease tags are hand-pushed via `make prerelease`, so that deliberate push *is* the approval and they skip the gate.
- **Remove the retired PR-pipeline gate.** The `production` gate on the pipeline `gate` job (now a no-op passthrough) and the dead copy on `agent-enforcer.yml` are gone.

## Net effect on a release PR

`Lint` + `Pytest` green → `release-autogreen` greens the required checks and arms auto-merge → PR merges to `dev` with **no per-PR human click**. release-please tags the release; the **stable deploy waits on the `production` environment approval** — the one and only human gate.

## Trade-off (recorded deliberately)

This is a **scoped exception** to the repo's "never merge without Nic" invariant (§5, `bypass_actors: null`), applying **only** to `release-please--*` head refs. It is safe because the content is deterministic bot output and the human decision is not removed but **relocated** to publish — nothing ships to users until the `production` environment is approved. Every other PR to `dev` runs the full agent pipeline and `admit-status` gate unchanged. Documented in `specs/workflows/pr-pipeline.md` §3.13.

## Tests

- `tests/test_release_please_fast_path.py` (new) — locks the skip guards, the `release-autogreen` wiring, the removed gate/environment, and the relocated deploy approval.
- `tests/test_pr_pipeline_review_gate.py` — all existing wiring + ruleset-alignment assertions still pass (25 passed total).

## Note

`typecheck` remains informational (non-required) per existing debt task `aops-1c3de214`; re-enabling it repo-wide is out of scope here. Release PRs still *run* Type Check; it just doesn't gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015vHCpQLkdssU1ceBEKFdqV)_