### PR TITLE
fix(pipeline): stop production deploy gate from cancelling pending approvals

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -27,8 +27,17 @@ on:
     tags: ['v*']
 
 concurrency:
+  # A stable tag's build-and-deploy job pauses on the `production` environment
+  # reviewer (the ONE human approval, §3.13) — while it's paused it is still
+  # "in progress" from concurrency's point of view. cancel-in-progress: true
+  # here silently cancelled that pending approval the instant the NEXT tag
+  # landed (release-please's fast path can cut one every few minutes), so a
+  # burst of releases each superseded the last before Nic ever saw a prompt —
+  # looked indistinguishable from "shipped with no approval" even though the
+  # cancelled runs never actually published. Queue instead: never drop a
+  # pending or completed deploy; each tag gets its own turn at the gate.
   group: build-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build-and-deploy:

--- a/specs/workflows/pr-pipeline.md
+++ b/specs/workflows/pr-pipeline.md
@@ -835,6 +835,17 @@ and Docker `:latest`. **Prerelease** tags (`vX.Y.Z-rc.N`, `-dev.N`, …; they co
 `-`) are hand-pushed via `make prerelease`, so that deliberate push *is* the approval
 and they skip the gate (`environment: ${{ !contains(github.ref_name, '-') && 'production' || '' }}`).
 
+**The gate queues, it never silently drops.** `build-extension.yml` serializes on the
+`build-deploy` concurrency group with `cancel-in-progress: false`. A run paused on the
+`production` reviewer is still "in progress" to GitHub's concurrency machinery — with
+`cancel-in-progress: true` (the bug: **fixed 2026-07-02**), each new stable tag from a
+release-please burst cancelled the previous run's pending approval outright, so most of
+a burst's releases vanished from the queue before Nic ever saw a prompt (visually
+indistinguishable from "shipped without approval," though the cancelled runs never
+actually reached `dist`/Docker). Queueing instead means every stable tag gets its own
+turn at the gate, in order; approving the newest still ships the full accumulated tree
+of everything behind it.
+
 > **Trade-off, recorded deliberately.** This is a scoped exception to the repository's
 > "never merge without Nic" invariant (§5, `bypass_actors: null`): a release PR merges
 > to `dev` with no per-PR human click. It is safe because (a) the content is

--- a/tests/test_release_please_fast_path.py
+++ b/tests/test_release_please_fast_path.py
@@ -101,3 +101,11 @@ def test_deploy_step_gates_stable_releases_on_production_environment():
     env = job.get("environment", "")
     assert "production" in env, env
     assert "contains(github.ref_name, '-')" in env, env  # prereleases skip the gate
+
+
+def test_deploy_concurrency_queues_instead_of_cancelling_pending_approval():
+    """A run paused on the `production` reviewer is still "in progress"; a fast-path
+    release burst must queue behind it, not cancel it — cancel-in-progress: true
+    silently dropped the pending approval the moment the next tag landed."""
+    concurrency = yaml.safe_load(BUILD.read_text())["concurrency"]
+    assert concurrency["cancel-in-progress"] is False, concurrency


### PR DESCRIPTION
## Summary

The release-please fast path (#2051) relocated the single human approval for a
release from the PR to the deploy step: a stable `vX.Y.Z` tag's
`build-and-deploy` job in `build-extension.yml` pauses on the `production`
GitHub Environment reviewer before publishing to `dist`/Docker.

`build-extension.yml`'s `build-deploy` concurrency group had
`cancel-in-progress: true`. A run paused waiting on the environment reviewer
is still "in progress" to GitHub's concurrency machinery, so when the fast
path cut a new stable tag (which it can do every few minutes once several
PRs merge to `dev`), the new tag's push **silently cancelled** the previous
run's pending approval before the reviewer ever saw a prompt. Confirmed
against today's run history: `v0.3.46`, `v0.3.47`, and `v0.3.48` were each
cancelled mid-wait by the next tag landing, and only `v0.3.45` (pre-fast-path)
and `v0.3.48-beta.0` (a prerelease, which intentionally skips the gate) ever
reached the `dist` branch. Nothing shipped without approval, but from the
maintainer's side a burst of releases appeared to sail through — the pending
approval kept vanishing before it could be acted on.

- `.github/workflows/build-extension.yml`: `cancel-in-progress: false` on the
  `build-deploy` concurrency group, so a release queues behind a pending
  approval instead of cancelling it — matching the same `cancel-in-progress:
  false` convention already used elsewhere in this pipeline for
  must-not-drop operations (`admit-on-review.yml`, `agent-mechanic.yml`).
- `specs/workflows/pr-pipeline.md` §3.13: documents the queueing behavior and
  the bug it fixes.
- `tests/test_release_please_fast_path.py`: locks in
  `cancel-in-progress: false` on the deploy concurrency group.

## Test plan

- [x] `uv run pytest tests/test_release_please_fast_path.py -v` — 8 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `./scripts/validate-ruleset-alignment.sh` — required checks still aligned
- [ ] Approve the currently-pending `v0.3.49` deploy (real, waiting since
      09:30 UTC) to confirm the environment gate still fires correctly after
      this change


---
_Generated by [Claude Code](https://claude.ai/code/session_0162WK8E9fRSAezn9zoGpHSU)_